### PR TITLE
installers/install_genome_data.sh:

### DIFF
--- a/installers/install_genome_data.sh
+++ b/installers/install_genome_data.sh
@@ -184,9 +184,9 @@ touch null
 
 if [[ ${TSS_ENRICH} != "" ]]; then
   wget -N -c ${TSS_ENRICH}
-  echo -e "tss\t${DEST_DIR}/ataqc/$(basename ${TSS_ENRICH})" >> ${TSV}
+  echo -e "tss_enrich\t${DEST_DIR}/ataqc/$(basename ${TSS_ENRICH})" >> ${TSV}
 else
-  echo -e "tss\t${DEST_DIR}/ataqc/null" >> ${TSV}
+  echo -e "tss_enrich\t${DEST_DIR}/ataqc/null" >> ${TSV}
 fi
 if [[ ${DNASE} != "" ]]; then
   wget -N -c ${DNASE}


### PR DESCRIPTION
  - all other code (atac.wdl and available genome files) refers to tss as tss_enrich. Leaving it
    as tss and adjusting the other code would be nicer, but this is the less intrusive fix.