### PR TITLE
keep backward compatibility for rep pair (repX-repY) index

### DIFF
--- a/atac.wdl
+++ b/atac.wdl
@@ -838,7 +838,12 @@ workflow atac {
 
 	# do IDR/overlap on all pairs of two replicates (i,j)
 	# 	where i and j are zero-based indices and 0 <= i < j < num_rep
-	Array[Pair[Int, Int]] pairs = cross(range(num_rep),range(num_rep))
+	Array[Pair[Int, Int]] pairs_ = cross(range(num_rep),range(num_rep))
+	scatter( pair in pairs_ ) {
+		Pair[Int, Int]? null_pair
+		Pair[Int, Int]? pairs__ = if pair.left<pair.right then pair else null_pair
+	}
+	Array[Pair[Int, Int]] pairs = select_all(pairs__)
 
 	scatter( pair in pairs ) {
 		# pair.left = 0-based index of 1st replicate
@@ -898,9 +903,7 @@ workflow atac {
 		}
 	}
 
-	scatter( i in range(num_rep*num_rep) ) {
-	# scatter( pair in pairs ) {
-		# Int idx = pair.left*num_rep + pair.right # enum index in "pairs"
+	scatter( i in range(length(pairs)) ) {
 		# take raw peak if blacklist doesn't exist
 		File? overlap_overlap_peak_ = 
 			if has_output_of_overlap[i] && defined(blacklist_) then overlap__bfilt_overlap_peak[i]
@@ -1076,7 +1079,7 @@ workflow atac {
 		# reproducibility QC for overlapping peaks
 		call reproducibility as reproducibility_overlap { input :
 			prefix = 'overlap',
-			peaks = select_all(overlap_overlap_peak_),
+			peaks = overlap_overlap_peak_,
 			peaks_pr = overlap_pr_overlap_peak_,
 			peak_ppr = overlap_ppr_overlap_peak_,
 			peak_type = peak_type,
@@ -1102,7 +1105,7 @@ workflow atac {
 		# reproducibility QC for IDR peaks
 		call reproducibility as reproducibility_idr { input :
 			prefix = 'idr',
-			peaks = select_all(idr_idr_peak_),
+			peaks = idr_idr_peak_,
 			peaks_pr = idr_pr_idr_peak_,
 			peak_ppr = idr_ppr_idr_peak_,
 			peak_type = peak_type,
@@ -1196,13 +1199,13 @@ workflow atac {
 		frip_macs2_qc_ppr1 = frip_macs2_qc_ppr1_,
 		frip_macs2_qc_ppr2 = frip_macs2_qc_ppr2_,
 		
-		idr_plots = select_all(idr_idr_plot_), # use select_all to get list of pairs (repX,repY) where X<Y
+		idr_plots = idr_idr_plot_,
 		idr_plots_pr = idr_pr_idr_plot_,
 		idr_plot_ppr = idr_ppr_idr_plot_,
-		frip_idr_qcs = select_all(idr_frip_qc_), # use select_all to get list of pairs (repX,repY) where X<Y
+		frip_idr_qcs = idr_frip_qc_,
 		frip_idr_qcs_pr = idr_pr_frip_qc_,
 		frip_idr_qc_ppr = idr_ppr_frip_qc_,
-		frip_overlap_qcs = select_all(overlap_frip_qc_), # use select_all to get list of pairs (repX,repY) where X<Y
+		frip_overlap_qcs = overlap_frip_qc_,
 		frip_overlap_qcs_pr = overlap_pr_frip_qc_,
 		frip_overlap_qc_ppr = overlap_ppr_frip_qc_,
 		idr_reproducibility_qc = reproducibility_idr_reproducibility_qc_,

--- a/atac.wdl
+++ b/atac.wdl
@@ -3,7 +3,7 @@
 
 workflow atac {
 	# pipeline version
-	String pipeline_ver = 'v1.1.7'
+	String pipeline_ver = 'v1.1.7.1'
 
 	# general sample information
 	String title = 'Untitled'

--- a/backends/backend.conf
+++ b/backends/backend.conf
@@ -20,9 +20,9 @@ backend {
           -N ${job_name} \
           -o ${out} \
           -e ${err} \
-          ${"-lselect=1:ncpus=" + cpu + ":mem=" + memory_mb/1024 + "gb"} \
-          ${"-lwalltime=" + time + ":0:0"} \
-          ${if gpu>1 then "-lngpus=" + gpu else ""} \
+          ${true="-lselect=1:ncpus=" false="" defined(cpu)}${cpu}${true=":mem=" false="" defined(memory_mb)}${memory_mb}${true="mb" false="" defined(memory_mb)} \
+          ${true="-lwalltime=" false="" defined(time)}${time}${true=":0:0" false="" defined(time)} \
+          ${true="-lngpus=" false="" gpu>1}${if gpu>1 then gpu else ""} \
           -V \
           ${script}
         """
@@ -51,9 +51,9 @@ backend {
           -N ${job_name} \
           -o ${out} \
           -e ${err} \
-          ${"-lselect=1:ncpus=" + cpu + ":mem=" + memory_mb/1024 + "gb"} \
-          ${"-lwalltime=" + time + ":0:0"} \
-          ${if gpu>1 then "-lngpus=" + gpu else ""} \
+          ${true="-lselect=1:ncpus=" false="" defined(cpu)}${cpu}${true=":mem=" false="" defined(memory_mb)}${memory_mb}${true="mb" false="" defined(memory_mb)} \
+          ${true="-lwalltime=" false="" defined(time)}${time}${true=":0:0" false="" defined(time)} \
+          ${true="-lngpus=" false="" gpu>1}${if gpu>1 then gpu else ""} \
           -V)
         """
         kill = "qdel ${job_id}"
@@ -89,11 +89,11 @@ backend {
           ${"-t " + time*60} \
           -n 1 \
           --ntasks-per-node=1 \
-          ${"--cpus-per-task=" + cpu} \
-          ${"--mem=" + memory_mb} \
+          ${true="--cpus-per-task=" false="" defined(cpu)}${cpu} \
+          ${true="--mem=" false="" defined(memory_mb)}${memory_mb} \
           ${"-p " + slurm_partition} \
           ${"--account " + slurm_account} \
-          ${"--gres gpu:" + gpu} \
+          ${true="--gres gpu:" false="" defined(gpu)}${gpu} \
           ${slurm_extra_param} \
           --wrap "chmod u+x ${script} && LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script}")
         """
@@ -129,11 +129,11 @@ backend {
           -wd ${cwd} \
           -o ${out} \
           -e ${err} \
-          ${if cpu>1 then "-pe " + sge_pe + " " + cpu else " "} \
-          ${"-l h_vmem=" + memory_mb/cpu + "m"} \
-          ${"-l s_vmem=" + memory_mb/cpu + "m"} \
-          ${"-l h_rt=" + time*3600} \
-          ${"-l s_rt=" + time*3600} \
+          ${if cpu>1 then "-pe " + sge_pe + " " else ""}${if cpu>1 then cpu else ""} \
+          ${true="-l h_vmem=$(expr " false="" defined(memory_mb)}${memory_mb}${true=" / " false="" defined(memory_mb)}${if defined(memory_mb) then cpu else ""}${true=")m" false="" defined(memory_mb)} \
+          ${true="-l s_vmem=$(expr " false="" defined(memory_mb)}${memory_mb}${true=" / " false="" defined(memory_mb)}${if defined(memory_mb) then cpu else ""}${true=")m" false="" defined(memory_mb)} \
+          ${true="-l h_rt=" false="" defined(time)}${time}${true=":00:00" false="" defined(time)}\
+          ${true="-l s_rt=" false="" defined(time)}${time}${true=":00:00" false="" defined(time)}\
           ${"-q " + sge_queue} \
           ${"-l gpu=" + gpu} \
           ${sge_extra_param} \
@@ -195,13 +195,13 @@ backend {
         -wd ${cwd} \
         -o ${out} \
         -e ${err} \
-        ${if cpu>1 then "-pe " + sge_pe + " " + cpu else " "} \
-        ${"-l h_vmem=" + memory_mb/cpu + "m"} \
-        ${"-l s_vmem=" + memory_mb/cpu + "m"} \
-        ${"-l h_rt=" + time*3600} \
-        ${"-l s_rt=" + time*3600} \
+        ${if cpu>1 then "-pe " + sge_pe + " " else ""}${if cpu>1 then cpu else ""} \
+        ${true="-l h_vmem=$(expr " false="" defined(memory_mb)}${memory_mb}${true=" / " false="" defined(memory_mb)}${if defined(memory_mb) then cpu else ""}${true=")m" false="" defined(memory_mb)} \
+        ${true="-l s_vmem=$(expr " false="" defined(memory_mb)}${memory_mb}${true=" / " false="" defined(memory_mb)}${if defined(memory_mb) then cpu else ""}${true=")m" false="" defined(memory_mb)} \
+        ${true="-l h_rt=" false="" defined(time)}${time}${true=":00:00" false="" defined(time)}\
+        ${true="-l s_rt=" false="" defined(time)}${time}${true=":00:00" false="" defined(time)}\
         ${"-q " + sge_queue} \
-        ${"-l gpu=" + gpu} \
+        ${true="-l gpu=" false="" defined(gpu)}${gpu} \
         ${sge_extra_param} \
         -V \
         ${script}
@@ -236,11 +236,11 @@ backend {
         ${"-t " + time*60} \
         -n 1 \
         --ntasks-per-node=1 \
-        ${"--cpus-per-task=" + cpu} \
-        ${"--mem=" + memory_mb} \
+        ${true="--cpus-per-task=" false="" defined(cpu)}${cpu} \
+        ${true="--mem=" false="" defined(memory_mb)}${memory_mb} \
         ${"-p " + slurm_partition} \
         ${"--account " + slurm_account} \
-        ${"--gres gpu:" + gpu} \
+        ${true="--gres gpu:" false="" defined(gpu)}${gpu} \
         ${slurm_extra_param} \
         --wrap "/bin/bash ${script}"
         """

--- a/backends/backend.conf
+++ b/backends/backend.conf
@@ -1,7 +1,7 @@
 include required(classpath("application"))
 
 backend {
-  default = "Local"
+  default = "local"
   providers {
 
     pbs {
@@ -47,14 +47,14 @@ backend {
           String? singularity_ld_library_path
         """
         submit = """
-          ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (echo "chmod u+x ${script} && LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script}" | qsub \
+          echo "LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}" | qsub \
           -N ${job_name} \
           -o ${out} \
           -e ${err} \
           ${true="-lselect=1:ncpus=" false="" defined(cpu)}${cpu}${true=":mem=" false="" defined(memory_mb)}${memory_mb}${true="mb" false="" defined(memory_mb)} \
           ${true="-lwalltime=" false="" defined(time)}${time}${true=":0:0" false="" defined(time)} \
           ${true="-lngpus=" false="" gpu>1}${if gpu>1 then gpu else ""} \
-          -V)
+          -V
         """
         kill = "qdel ${job_id}"
         check-alive = "qstat -j ${job_id}"
@@ -80,7 +80,7 @@ backend {
           String? singularity_ld_library_path
         """
         submit = """
-          ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (sbatch \
+          sbatch \
           --export=ALL \
           -J ${job_name} \
           -D ${cwd} \
@@ -95,7 +95,7 @@ backend {
           ${"--account " + slurm_account} \
           ${true="--gres gpu:" false="" defined(gpu)}${gpu} \
           ${slurm_extra_param} \
-          --wrap "chmod u+x ${script} && LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script}")
+          --wrap "LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}"
         """
         kill = "scancel ${job_id}"
         check-alive = "squeue -j ${job_id}"
@@ -121,7 +121,7 @@ backend {
           String? singularity_ld_library_path
         """
         submit = """
-          ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (echo "chmod u+x ${script} && LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script}" | qsub \
+          echo "LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}" | qsub \
           -S /bin/sh \
           -terse \
           -b n \
@@ -137,7 +137,7 @@ backend {
           ${"-q " + sge_queue} \
           ${"-l gpu=" + gpu} \
           ${sge_extra_param} \
-          -V)
+          -V
         """
         kill = "qdel ${job_id}"
         check-alive = "qstat -j ${job_id}"
@@ -150,6 +150,7 @@ backend {
       config {
         script-epilogue = "sleep 5 && sync"
         concurrent-job-limit = 10
+        run-in-background = true
         runtime-attributes = """
           Int? gpu
           String singularity_container
@@ -157,15 +158,19 @@ backend {
           String? singularity_ld_library_path
         """
         submit = """
-          ls ${singularity_container} $(echo ${singularity_bindpath} | tr , ' ') 1>/dev/null && (chmod u+x ${script} && LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} ${script} & echo $! && disown)
+          LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}
         """
-        job-id-regex = "(\\d+)"
-        check-alive = "ps -ef | grep -v grep | grep ${job_id}" 
-        kill = "kill -9 ${job_id}"
       }
     }
 
     Local {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+      config {
+        concurrent-job-limit = 10
+      }
+    }
+
+    local {
       actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
       config {
         concurrent-job-limit = 10

--- a/backends/backend.conf
+++ b/backends/backend.conf
@@ -55,7 +55,22 @@ backend {
           ${true="-lwalltime=" false="" defined(time)}${time}${true=":0:0" false="" defined(time)} \
           ${true="-lngpus=" false="" gpu>1}${if gpu>1 then gpu else ""} \
           -V
+          # If you see an error "The job was aborted from outside Cromwell"
+          #   then check your singularity settings in a workflow options JSON file
+          #   (e.g. check if you have an image file defined by "singularity_container")
+          # Also, make sure that your input data files (and genome database files)
+          #   are on directories recursively bound by
+          #   "singularity_bindpath" in a workflow options JSON file
+          #   or singularity's built-in environment variable SINGULARITY_BINDPATH.
         """
+        # cromwell is desinged to monitor rc (return code) file, which is generated/controlled
+        # in ${script}, so if singularity does not run it due to some problems in singuarlity's
+        # internal settings then rc file is not generated.
+        # this can result in hanging of a cromwell process.
+        # setting the below parameter enables monitoring by "check-alive".
+        # it will take about "exit-code-timeout-seconds" x 3 time to detect failure.
+        exit-code-timeout-seconds = 180
+
         kill = "qdel ${job_id}"
         check-alive = "qstat -j ${job_id}"
         job-id-regex = "(\\d+)"
@@ -65,7 +80,7 @@ backend {
     slurm_singularity {
       actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
       config {
-        script-epilogue = "sleep 30"
+        script-epilogue = "sleep 30 && sync"
         concurrent-job-limit = 50
         runtime-attributes = """
           Int cpu = 1
@@ -96,9 +111,27 @@ backend {
           ${true="--gres gpu:" false="" defined(gpu)}${gpu} \
           ${slurm_extra_param} \
           --wrap "LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}"
+          # If you see an error "The job was aborted from outside Cromwell"
+          #   then check your singularity settings in a workflow options JSON file
+          #   (e.g. check if you have an image file defined by "singularity_container")
+          # Also, make sure that your input data files (and genome database files)
+          #   are on directories recursively bound by
+          #   "singularity_bindpath" in a workflow options JSON file
+          #   or singularity's built-in environment variable SINGULARITY_BINDPATH.
         """
         kill = "scancel ${job_id}"
-        check-alive = "squeue -j ${job_id}"
+        # cromwell is desinged to monitor rc (return code) file, which is generated/controlled
+        # in ${script}, so if singularity does not run it due to some problems in singuarlity's
+        # internal settings then rc file is not generated.
+        # this can result in hanging of a cromwell process.
+        # setting the below parameter enables monitoring by "check-alive".
+        # it will take about "exit-code-timeout-seconds" x 3 time to detect failure.
+        exit-code-timeout-seconds = 180
+
+        # cromwell responds only to non-zero exit code from "check-alive",
+        # but "squeue -j [JOB_ID]" returns zero exit code even when job is not found
+        # workaround to exit with 1 (like SGE's qstat -j [JOB_ID] does) for such cases.
+        check-alive = "CHK_ALIVE=$(squeue --noheader -j ${job_id}); if [ -z $CHK_ALIVE ]; then /bin/bash -c 'exit 1'; else echo $CHK_ALIVE; fi"
         job-id-regex = "Submitted batch job (\\d+).*"
       }
     }
@@ -138,7 +171,22 @@ backend {
           ${"-l gpu=" + gpu} \
           ${sge_extra_param} \
           -V
+          # If you see an error "The job was aborted from outside Cromwell"
+          #   then check your singularity settings in a workflow options JSON file
+          #   (e.g. check if you have an image file defined by "singularity_container")
+          # Also, make sure that your input data files (and genome database files)
+          #   are on directories recursively bound by
+          #   "singularity_bindpath" in a workflow options JSON file
+          #   or singularity's built-in environment variable SINGULARITY_BINDPATH.
         """
+        # cromwell is desinged to monitor rc (return code) file, which is generated/controlled
+        # in ${script}, so if singularity does not run it due to some problems in singuarlity's
+        # internal settings then rc file is not generated.
+        # this can result in hanging of a cromwell process.
+        # setting the below parameter enables monitoring by "check-alive".
+        # it will take about "exit-code-timeout-seconds" x 3 time to detect failure.
+        exit-code-timeout-seconds = 180
+
         kill = "qdel ${job_id}"
         check-alive = "qstat -j ${job_id}"
         job-id-regex = "(\\d+)"

--- a/backends/backend.conf
+++ b/backends/backend.conf
@@ -44,10 +44,9 @@ backend {
           Int? memory_mb
           String singularity_container
           String? singularity_bindpath
-          String? singularity_ld_library_path
         """
         submit = """
-          echo "LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}" | qsub \
+          echo "SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}" | qsub \
           -N ${job_name} \
           -o ${out} \
           -e ${err} \
@@ -92,7 +91,6 @@ backend {
           String? slurm_extra_param
           String singularity_container
           String? singularity_bindpath
-          String? singularity_ld_library_path
         """
         submit = """
           sbatch \
@@ -110,7 +108,7 @@ backend {
           ${"--account " + slurm_account} \
           ${true="--gres gpu:" false="" defined(gpu)}${gpu} \
           ${slurm_extra_param} \
-          --wrap "LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}"
+          --wrap "SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}"
           # If you see an error "The job was aborted from outside Cromwell"
           #   then check your singularity settings in a workflow options JSON file
           #   (e.g. check if you have an image file defined by "singularity_container")
@@ -151,10 +149,9 @@ backend {
           String? sge_extra_param
           String singularity_container
           String? singularity_bindpath
-          String? singularity_ld_library_path
         """
         submit = """
-          echo "LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}" | qsub \
+          echo "SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}" | qsub \
           -S /bin/sh \
           -terse \
           -b n \
@@ -203,10 +200,9 @@ backend {
           Int? gpu
           String singularity_container
           String? singularity_bindpath
-          String? singularity_ld_library_path
         """
         submit = """
-          LD_LIBRARY_PATH=${singularity_ld_library_path}:$LD_LIBRARY_PATH SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}
+          SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}
         """
       }
     }

--- a/backends/backend.conf
+++ b/backends/backend.conf
@@ -46,7 +46,7 @@ backend {
           String? singularity_bindpath
         """
         submit = """
-          echo "SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}" | qsub \
+          echo "SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1)cromwell-executions,${singularity_bindpath},$SINGULARITY_BINDPATH singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}" | qsub \
           -N ${job_name} \
           -o ${out} \
           -e ${err} \
@@ -108,7 +108,7 @@ backend {
           ${"--account " + slurm_account} \
           ${true="--gres gpu:" false="" defined(gpu)}${gpu} \
           ${slurm_extra_param} \
-          --wrap "SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}"
+          --wrap "SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1)cromwell-executions,${singularity_bindpath},$SINGULARITY_BINDPATH singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}"
           # If you see an error "The job was aborted from outside Cromwell"
           #   then check your singularity settings in a workflow options JSON file
           #   (e.g. check if you have an image file defined by "singularity_container")
@@ -151,7 +151,7 @@ backend {
           String? singularity_bindpath
         """
         submit = """
-          echo "SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}" | qsub \
+          echo "SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1)cromwell-executions,${singularity_bindpath},$SINGULARITY_BINDPATH singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}" | qsub \
           -S /bin/sh \
           -terse \
           -b n \
@@ -202,7 +202,7 @@ backend {
           String? singularity_bindpath
         """
         submit = """
-          SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1),${singularity_bindpath} singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}
+          SINGULARITY_BINDPATH=$(echo ${cwd} | sed 's/cromwell-executions/\n/g' | head -n1)cromwell-executions,${singularity_bindpath},$SINGULARITY_BINDPATH singularity exec --cleanenv --home ${cwd} ${if defined(gpu) then '--nv' else ''} ${singularity_container} /bin/bash ${script}
         """
       }
     }

--- a/conda/requirements.txt
+++ b/conda/requirements.txt
@@ -15,7 +15,7 @@ macs2 ==2.1.1.20160309 #2.1.0 (no binaries for OSX)
 boost #==1.57.0
 openblas ==0.2.20
 numpy ==1.11.3 #1.10.2 (no binaries for OSX) #1.9.0, 1.8.2 conflicts with ATAQC
-matplotlib #==1.5.1
+matplotlib ==1.5.3 #==1.5.1
 six==1.11.0 # to fix (ImportError: cannot import name _thread)
 python-dateutil==2.6.1
 libgfortran==3.0

--- a/conda/requirements.txt
+++ b/conda/requirements.txt
@@ -12,26 +12,26 @@ ucsc-bedclip
 ucsc-bedtobigbed
 ucsc-twobittofa
 macs2 ==2.1.1.20160309 #2.1.0 (no binaries for OSX)
-boost ==1.57.0
+boost #==1.57.0
 openblas ==0.2.20
 numpy ==1.11.3 #1.10.2 (no binaries for OSX) #1.9.0, 1.8.2 conflicts with ATAQC
 matplotlib #==1.5.1
 six==1.11.0 # to fix (ImportError: cannot import name _thread)
 python-dateutil==2.6.1
 libgfortran==3.0
-graphviz ==2.38.0
+#graphviz ==2.38.0
 libtool
 ghostscript # pdf2png
 pigz
 zlib
 sambamba ==0.6.6 # to fix seg fault error in 0.6.1
-r ==3.2.2
+r ==3.3.2 #3.2.2
 r-snow
 r-snowfall
 r-bitops
 r-catools
 bioconductor-rsamtools
-r-spp ==1.13
+r-spp ==1.14 #1.13
 #glibc #segmentation fault in conda with openssl
 pyfaidx ==0.4.7.1
 

--- a/conda/requirements_py3.txt
+++ b/conda/requirements_py3.txt
@@ -8,7 +8,7 @@ bedtools ==2.26.0
 java-jdk ==8.0.92
 # to resolve 'CXXABI_1.3.9' not found issue
 libgcc==5.2.0 # this does not work with MacOS...
-matplotlib #==1.5.1
+matplotlib ==1.5.3 #==1.5.1
 ncurses ==6.1
 tabix==0.2.6
 readline=6.2

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -2,9 +2,9 @@
 
 ## Command line for version change
 ```bash
-PREV_VER=v1.1.7
-NEW_VER=v1.1.7
-for f in $(grep -rl ${PREV_VER} --include=*.{wdl,md,sh,yml})
+PREV_VER=v1.1.7.1
+NEW_VER=v1.1.7.1
+for f in $(grep -rl ${PREV_VER} --include=*.{wdl,md,sh})
 do
   sed -i "s/${PREV_VER}/${NEW_VER}/g" ${f}
 done
@@ -24,7 +24,7 @@ Run the following command line locally to build out DX workflows for this pipeli
 
 ```bash
 # version
-VER=v1.1.7
+VER=v1.1.7.1
 
 # general
 java -jar ~/dxWDL-0.77.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras workflow_opts/docker.json -f -folder /ATAC-seq/workflows/$VER/general -defaults examples/dx/template_general.json

--- a/docs/input.md
+++ b/docs/input.md
@@ -84,21 +84,21 @@ Let us take a close look at the following template JSON. Comments are not allowe
     "atac.fastqs_rep2_R2" : [ "rep2_R2_L1.fastq.gz", "rep2_R2_L2.fastq.gz" ],
 
     // If you start from BAMs then define these, otherwise remove from this file.
-    // You can define up to 6 replicates. The following example array has two replicates.
+    // You can define up to 10 replicates. The following example array has two replicates.
     "atac.bams" : [
         "raw_rep1.bam",
         "raw_rep2.bam"
     ],
 
     // If you start from filtered/deduped BAMs then define these, otherwise remove from this file.
-    // You can define up to 6 replicates. The following example array has two replicates.
+    // You can define up to 10 replicates. The following example array has two replicates.
     "atac.nodup_bams" : [
         "nodup_rep1.bam",
         "nodup_rep2.bam"
     ],
 
     // If you start from TAG-ALIGNs then define these, otherwise remove from this file.
-    // You can define up to 6 replicates. The following example array has two replicates.
+    // You can define up to 10 replicates. The following example array has two replicates.
     "atac.tas" : [
         "rep1.tagAlign.gz",
         "rep2.tagAlign.gz"

--- a/docs/tutorial_dx_web.md
+++ b/docs/tutorial_dx_web.md
@@ -15,8 +15,8 @@ This document describes instruction for the item 2).
 
 3. Move to one of the following workflow directories according to the platform you have chosen for your project (AWS or Azure). These DX workflows are pre-built with all parameters defined.
 
-* [AWS test workflow](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7/test_ENCSR356KRQ_subsampled)
-* [Azure test workflow](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7/test_ENCSR356KRQ_subsampled)
+* [AWS test workflow](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7.1/test_ENCSR356KRQ_subsampled)
+* [Azure test workflow](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7.1/test_ENCSR356KRQ_subsampled)
 
 4. Copy it to your project by right-clicking on the DX workflow `atac` and choose "Copy". 
 
@@ -40,16 +40,16 @@ This document describes instruction for the item 2).
 1. DNAnexus allows only one copy of a workflow per project. The example workflow in the previous section is pre-built for the subsampled test sample [ENCSR356KRQ](https://www.encodeproject.org/experiments/ENCSR356KRQ/) with all parameters defined already.
 
 2. Copy one of the following workflows according to the platform you have chosen for your project (AWS or Azure).
-* [AWS general](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7/general) without pre-defined reference genome.
-* [AWS hg38](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7/hg38) with pre-defined hg38 reference genome.
-* [AWS hg19](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7/hg19) with pre-defined hg19 reference genome.
-* [AWS mm10](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7/mm10) with pre-defined mm10 reference genome.
-* [AWS mm9](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7/mm9) with pre-defined mm9 reference genome.
-* [Azure general](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7/general) without pre-defined reference genome.
-* [Azure hg38](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7/hg38) with pre-defined hg38 reference genome.
-* [Azure hg19](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7/hg19) with pre-defined hg19 reference genome.
-* [Azure mm10](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7/mm10) with pre-defined mm10 reference genome.
-* [Azure mm9](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7/mm9) with pre-defined mm9 reference genome.
+* [AWS general](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7.1/general) without pre-defined reference genome.
+* [AWS hg38](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7.1/hg38) with pre-defined hg38 reference genome.
+* [AWS hg19](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7.1/hg19) with pre-defined hg19 reference genome.
+* [AWS mm10](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7.1/mm10) with pre-defined mm10 reference genome.
+* [AWS mm9](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.1.7.1/mm9) with pre-defined mm9 reference genome.
+* [Azure general](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7.1/general) without pre-defined reference genome.
+* [Azure hg38](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7.1/hg38) with pre-defined hg38 reference genome.
+* [Azure hg19](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7.1/hg19) with pre-defined hg19 reference genome.
+* [Azure mm10](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7.1/mm10) with pre-defined mm10 reference genome.
+* [Azure mm9](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.1.7.1/mm9) with pre-defined mm9 reference genome.
 
 3. Click on the DX workflow `atac`.
 

--- a/docs/tutorial_local_singularity.md
+++ b/docs/tutorial_local_singularity.md
@@ -33,7 +33,7 @@
 
 6. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.1.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7.1
     ```
 
 7. Run a pipeline for the test sample.
@@ -53,7 +53,7 @@
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.7.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.7.1.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/tutorial_scg.md
+++ b/docs/tutorial_scg.md
@@ -68,7 +68,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg",
+            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.1.simg",
             "singularity_bindpath" : "/reference/ENCODE,/scratch,/srv/gsfs0,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/tutorial_scg_backend.md
+++ b/docs/tutorial_scg_backend.md
@@ -58,7 +58,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 5. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
     $ sdev    # SCG cluster does not allow building a container on login node
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.1.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7.1
     $ exit
     ```
 
@@ -76,7 +76,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.7.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.7.1.simg",
             "singularity_bindpath" : "/scratch/users,/srv/gsfs0,/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/tutorial_sge.md
+++ b/docs/tutorial_sge.md
@@ -61,7 +61,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.1.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7.1
     ```
 
 8. Run a pipeline for the test sample. If your parallel environment (PE) found from step 5) has a different name from `shm` then edit the following shell script to change the PE name.
@@ -83,7 +83,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg",
+            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.1.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR2,..."
         }
     }

--- a/docs/tutorial_sge_backend.md
+++ b/docs/tutorial_sge_backend.md
@@ -67,7 +67,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.1.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1
     ```
 
 8. Run a pipeline for the test sample.

--- a/docs/tutorial_sherlock.md
+++ b/docs/tutorial_sherlock.md
@@ -68,7 +68,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg",
+            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.1.simg",
             "singularity_bindpath" : "/scratch,/lscratch,/oak/stanford,/home/groups/cherry/encode,/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/tutorial_sherlock_backend.md
+++ b/docs/tutorial_sherlock_backend.md
@@ -63,7 +63,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 6. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`. Stanford Sherlock does not allow building a container on login nodes. Wait until you get a command prompt after `sdev`.
     ```bash
     $ sdev    # sherlock cluster does not allow building a container on login node
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.1.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7.1
     $ exit    # exit from an interactive node
     ```
 
@@ -81,7 +81,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.7.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.7.1.simg",
             "singularity_bindpath" : "/scratch,/oak/stanford,/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/tutorial_slurm.md
+++ b/docs/tutorial_slurm.md
@@ -56,7 +56,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.1.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7.1
     ```
 
 8. Run a pipeline for the test sample. If your cluster requires to specify any of them then add one to the command line.
@@ -78,7 +78,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg",
+            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.1.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR2,..."
         }
     }

--- a/docs/tutorial_slurm_backend.md
+++ b/docs/tutorial_slurm_backend.md
@@ -68,7 +68,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.1.7.1.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1.7.1
     ```
 
 8. Run a pipeline for the test sample.
@@ -85,7 +85,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.7.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.1.7.1.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR2,..."
         }
     }

--- a/src/encode_common_genomic.py
+++ b/src/encode_common_genomic.py
@@ -209,7 +209,7 @@ def subsample_ta_pe(ta, subsample, non_mito, mito_chr_name, r1_only, out_dir):
     return ta_subsampled
 
 # convert encode peak file to hammock (for Wash U browser track)
-def peak_to_hammock(peak, out_dir):
+def peak_to_hammock(peak, keep_irregular_chr, out_dir):
     peak_type = get_peak_type(peak)
     prefix = os.path.join(out_dir, os.path.basename(
         strip_ext_peak(peak)))
@@ -224,7 +224,10 @@ def peak_to_hammock(peak, out_dir):
         run_shell_cmd(cmd)
         cmd2 = 'touch {}'.format(hammock_gz_tbi)
     else:
-        cmd = "zcat -f {} | sed '/^\(chr\)/!d' | LC_COLLATE=C sort -k1,1V -k2,2n > {}"
+        cmd = "zcat -f {} | "
+        if not keep_irregular_chr:
+            cmd += "sed '/^\(chr\)/!d' | "
+        cmd += "LC_COLLATE=C sort -k1,1V -k2,2n > {}"
         cmd = cmd.format(peak, hammock_tmp)
         run_shell_cmd(cmd)
 

--- a/src/encode_idr.py
+++ b/src/encode_idr.py
@@ -147,7 +147,7 @@ def main():
     peak_to_bigbed(bfilt_idr_peak, args.peak_type, args.chrsz, args.keep_irregular_chr, args.out_dir)
 
     log.info('Converting peak to hammock...')
-    peak_to_hammock(bfilt_idr_peak, args.out_dir)
+    peak_to_hammock(bfilt_idr_peak, args.keep_irregular_chr, args.out_dir)
 
     if args.ta: # if TAG-ALIGN is given
         if args.fraglen: # chip-seq

--- a/src/encode_macs2_atac.py
+++ b/src/encode_macs2_atac.py
@@ -202,7 +202,7 @@ def main():
     peak_to_bigbed(bfilt_npeak, 'narrowPeak', args.chrsz, args.keep_irregular_chr, args.out_dir)
 
     log.info('Converting peak to hammock...')
-    peak_to_hammock(bfilt_npeak, args.out_dir)
+    peak_to_hammock(bfilt_npeak, args.keep_irregular_chr, args.out_dir)
 
     if args.ta: # if TAG-ALIGN is given
         log.info('FRiP without fragment length...')

--- a/src/encode_naive_overlap.py
+++ b/src/encode_naive_overlap.py
@@ -121,7 +121,7 @@ def main():
     peak_to_bigbed(bfilt_overlap_peak, args.peak_type, args.chrsz, args.keep_irregular_chr, args.out_dir)
 
     log.info('Converting peak to hammock...')
-    peak_to_hammock(bfilt_overlap_peak, args.out_dir)
+    peak_to_hammock(bfilt_overlap_peak, args.keep_irregular_chr, args.out_dir)
 
     if args.ta: # if TAG-ALIGN is given
         if args.fraglen: # chip-seq

--- a/src/encode_reproducibility_qc.py
+++ b/src/encode_reproducibility_qc.py
@@ -117,8 +117,8 @@ def main():
         peak_to_bigbed(conservative_peak_file, args.peak_type, args.chrsz, args.keep_irregular_chr, args.out_dir)
 
         log.info('Converting peak to hammock...')
-        peak_to_hammock(optimal_peak_file, args.out_dir)
-        peak_to_hammock(conservative_peak_file, args.out_dir)
+        peak_to_hammock(optimal_peak_file, args.keep_irregular_chr, args.out_dir)
+        peak_to_hammock(conservative_peak_file, args.keep_irregular_chr, args.out_dir)
 
     log.info('Writing reproducibility QC log...')
     if args.prefix:

--- a/src/run_ataqc.py
+++ b/src/run_ataqc.py
@@ -844,7 +844,7 @@ def get_peak_counts(raw_peaks, naive_overlap_peaks=None, idr_peaks=None):
 
     # Literally just throw these into a QC table
     results = []
-    results.append(QCGreaterThanEqualCheck('Raw peaks', 10000)(raw_count))
+    # results.append(QCGreaterThanEqualCheck('Raw peaks', 10000)(raw_count))
     results.append(QCGreaterThanEqualCheck('Naive overlap peaks',
                                            10000)(naive_count))
     results.append(QCGreaterThanEqualCheck('IDR peaks', 10000)(idr_count))

--- a/test/test_task/test.sh
+++ b/test/test_task/test.sh
@@ -12,7 +12,7 @@ INPUT=$2
 if [ $# -gt 2 ]; then
   DOCKER_IMAGE=$3
 else
-  DOCKER_IMAGE=quay.io/encode-dcc/atac-seq-pipeline:test-v1.1.7
+  DOCKER_IMAGE=quay.io/encode-dcc/atac-seq-pipeline:test-v1.1.7.1
 fi
 if [ $# -gt 3 ]; then
   NUM_TASK=$4

--- a/test/test_task/test_ataqc.json
+++ b/test/test_task/test_ataqc.json
@@ -26,7 +26,7 @@
     "test_ataqc.overlap_peak" : "atac-seq-pipeline-test-data/input/pe/ataqc/test_ataqc_full_chr_ppr.naive_overlap.filt.narrowPeak.gz",
     "test_ataqc.pval_bw" : "atac-seq-pipeline-test-data/input/pe/ataqc/ENCFF341MYG.subsampled.400.trim.merged.nodup.tn5.pval.signal.bigwig",
 
-    "test_ataqc.ref_qc_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/ENCFF341MYG.subsampled.400.trim.merged_qc.txt",
+    "test_ataqc.ref_qc_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/v1.1.7.a/ENCFF341MYG.subsampled.400.trim.merged_qc.txt",
     "test_ataqc.ref_qc_align_only_1_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/align_only_1/ENCFF341MYG.subsampled.400.trim.merged.nodup_qc.txt",
     "test_ataqc.ref_qc_align_only_2_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/align_only_2/ENCFF341MYG.subsampled.400.trim.merged_qc.txt",
     "test_ataqc.ref_qc_peak_only_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/peak_only/test_ataqc_full_chr_rep1-pr.IDR0.05.filt_qc.txt",

--- a/test/test_workflow/ENCSR356KRQ.json
+++ b/test/test_workflow/ENCSR356KRQ.json
@@ -1,5 +1,5 @@
 {
-    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6/ENCSR356KRQ/qc.json",
+    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6.a/ENCSR356KRQ/qc.json",
     "atac.pipeline_type" : "atac",
     "atac.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_google.tsv",
     "atac.fastqs_rep1_R1" : [

--- a/test/test_workflow/ENCSR356KRQ_subsampled.json
+++ b/test/test_workflow/ENCSR356KRQ_subsampled.json
@@ -1,5 +1,5 @@
 {
-    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6/ENCSR356KRQ_subsampled/qc.json",
+    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6.a/ENCSR356KRQ_subsampled/qc.json",
     "atac.pipeline_type" : "atac",
     "atac.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_google.tsv",
     "atac.fastqs_rep1_R1" : [

--- a/test/test_workflow/ENCSR356KRQ_subsampled_chr19_only.json
+++ b/test/test_workflow/ENCSR356KRQ_subsampled_chr19_only.json
@@ -1,5 +1,5 @@
 {
-    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6/ENCSR356KRQ_subsampled_chr19_only/qc.json",
+    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6.a/ENCSR356KRQ_subsampled_chr19_only/qc.json",
     "atac.pipeline_type" : "atac",
     "atac.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_chr19_chrM_google.tsv",
     "atac.fastqs_rep1_R1" : [

--- a/test/test_workflow/ENCSR889WQX.json
+++ b/test/test_workflow/ENCSR889WQX.json
@@ -1,5 +1,5 @@
 {
-    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6/ENCSR889WQX/qc.json",
+    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6.a/ENCSR889WQX/qc.json",
     "atac.pipeline_type" : "atac",
     "atac.genome_tsv" : "gs://encode-pipeline-genome-data/mm10_google.tsv",
     "atac.fastqs_rep1_R1" : [

--- a/test/test_workflow/ENCSR889WQX_subsampled.json
+++ b/test/test_workflow/ENCSR889WQX_subsampled.json
@@ -1,5 +1,5 @@
 {
-    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6/ENCSR889WQX_subsampled/qc.json",
+    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6.a/ENCSR889WQX_subsampled/qc.json",
     "atac.pipeline_type" : "atac",
     "atac.genome_tsv" : "gs://encode-pipeline-genome-data/mm10_google.tsv",
     "atac.fastqs_rep1_R1" : [

--- a/test/test_workflow/ENCSR889WQX_subsampled_chr19_only.json
+++ b/test/test_workflow/ENCSR889WQX_subsampled_chr19_only.json
@@ -1,5 +1,5 @@
 {
-    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6/ENCSR889WQX_subsampled_chr19_only/qc.json",
+    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6.a/ENCSR889WQX_subsampled_chr19_only/qc.json",
     "atac.pipeline_type" : "atac",
     "atac.genome_tsv" : "gs://encode-pipeline-genome-data/mm10_chr19_chrM_google.tsv",
     "atac.fastqs_rep1_R1" : [

--- a/test/test_workflow/ref_output/v1.1.6.a/ENCSR356KRQ/qc.json
+++ b/test/test_workflow/ref_output/v1.1.6.a/ENCSR356KRQ/qc.json
@@ -1,0 +1,454 @@
+{
+    "general": {
+        "date": "2019-01-23 01:41:13", 
+        "pipeline_ver": "v1.1.6", 
+        "peak_caller": "macs2", 
+        "genome": "hg38_google.tsv", 
+        "description": "ATAC-seq on primary keratinocytes in day 0.0 of differentiation", 
+        "title": "ENCSR356KRQ", 
+        "paired_end": true
+    }, 
+    "flagstat_qc": {
+        "rep1": {
+            "total": 514593434, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 512447965, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 99.58, 
+            "paired": 276305638, 
+            "paired_qc_failed": 0, 
+            "read1": 138152819, 
+            "read1_qc_failed": 0, 
+            "read2": 138152819, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 242132432, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 87.63, 
+            "with_itself": 273772850, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 387319, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.14, 
+            "diff_chroms": 211289, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 656853982, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 655653211, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 99.82, 
+            "paired": 338971378, 
+            "paired_qc_failed": 0, 
+            "read1": 169485689, 
+            "read1_qc_failed": 0, 
+            "read2": 169485689, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 298805416, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 88.15, 
+            "with_itself": 337181554, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 589053, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.17, 
+            "diff_chroms": 292923, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "dup_qc": {
+        "rep1": {
+            "unpaired_reads": 0, 
+            "paired_reads": 88210252, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 0, 
+            "paired_dupes": 22636036, 
+            "paired_opt_dupes": 643092, 
+            "dupes_pct": 0.256615
+        }, 
+        "rep2": {
+            "unpaired_reads": 0, 
+            "paired_reads": 105533907, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 0, 
+            "paired_dupes": 20185281, 
+            "paired_opt_dupes": 908157, 
+            "dupes_pct": 0.191268
+        }
+    }, 
+    "pbc_qc": {
+        "rep1": {
+            "total_read_pairs": 84000590, 
+            "distinct_read_pairs": 64499628, 
+            "one_read_pair": 50242358, 
+            "two_read_pair": 11070649, 
+            "NRF": 0.767847, 
+            "PBC1": 0.778956, 
+            "PBC2": 4.538339
+        }, 
+        "rep2": {
+            "total_read_pairs": 99388201, 
+            "distinct_read_pairs": 83856937, 
+            "one_read_pair": 72226468, 
+            "two_read_pair": 9766236, 
+            "NRF": 0.843731, 
+            "PBC1": 0.861306, 
+            "PBC2": 7.395528
+        }
+    }, 
+    "nodup_flagstat_qc": {
+        "rep1": {
+            "total": 131148432, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 131148432, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 131148432, 
+            "paired_qc_failed": 0, 
+            "read1": 65574216, 
+            "read1_qc_failed": 0, 
+            "read2": 65574216, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 131148432, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 100.0, 
+            "with_itself": 131148432, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 170697252, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 170697252, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 170697252, 
+            "paired_qc_failed": 0, 
+            "read1": 85348626, 
+            "read1_qc_failed": 0, 
+            "read2": 85348626, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 170697252, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 100.0, 
+            "with_itself": 170697252, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "overlap_reproducibility_qc": {
+        "Nt": 271192, 
+        "N1": 261791, 
+        "N2": 265543, 
+        "Np": 276203, 
+        "N_opt": 276203, 
+        "N_consv": 271192, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.01847768371, 
+        "self_consistency_ratio": 1.0143320435, 
+        "reproducibility": "pass"
+    }, 
+    "idr_reproducibility_qc": {
+        "Nt": 194475, 
+        "N1": 174221, 
+        "N2": 184650, 
+        "Np": 198674, 
+        "N_opt": 198674, 
+        "N_consv": 194475, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.0215914642, 
+        "self_consistency_ratio": 1.05986075157, 
+        "reproducibility": "pass"
+    }, 
+    "xcor_score": {
+        "rep1": {
+            "num_reads": 25000000, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.394074945839069, 
+            "phantom_peak": 75, 
+            "corr_phantom_peak": 0.3368846, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.1907317, 
+            "NSC": 2.066122, 
+            "RSC": 1.391305
+        }, 
+        "rep2": {
+            "num_reads": 25000000, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.377563704457927, 
+            "phantom_peak": 70, 
+            "corr_phantom_peak": 0.3299829, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.2007699, 
+            "NSC": 1.880579, 
+            "RSC": 1.368235
+        }
+    }, 
+    "frip_macs2_qc": {
+        "rep1": {
+            "FRiP": 0.38494058153
+        }, 
+        "rep2": {
+            "FRiP": 0.352136636204
+        }, 
+        "rep1-pr1": {
+            "FRiP": 0.381963300989
+        }, 
+        "rep2-pr1": {
+            "FRiP": 0.345366787658
+        }, 
+        "rep1-pr2": {
+            "FRiP": 0.38164361334
+        }, 
+        "rep2-pr2": {
+            "FRiP": 0.346604548575
+        }, 
+        "pooled": {
+            "FRiP": 0.369201077428
+        }, 
+        "ppr1": {
+            "FRiP": 0.366524841191
+        }, 
+        "ppr2": {
+            "FRiP": 0.365921638814
+        }
+    }, 
+    "overlap_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.357628110185
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.36939330905
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.339288596219
+        }, 
+        "ppr": {
+            "FRiP": 0.359864986
+        }
+    }, 
+    "idr_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.315840345262
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.318365303511
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.295646514218
+        }, 
+        "ppr": {
+            "FRiP": 0.319264856788
+        }
+    }, 
+    "ataqc": {
+        "rep1": {
+            "Genome": "GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz", 
+            "Paired/Single-ended": "Paired-ended", 
+            "Read length": 76, 
+            "Read count from sequencer": 514593434, 
+            "Read count successfully aligned": 512447965, 
+            "Read count after filtering for mapping quality": 354109333, 
+            "Read count after removing duplicate reads": 331473297, 
+            "Read count after removing mitochondrial reads (final read count)": 131148432, 
+            "Mapping quality > q30 (out of total)": [
+                354109333, 
+                0.688134184394
+            ], 
+            "Duplicates (after filtering)": [
+                22636036, 
+                0.256615
+            ], 
+            "Mitochondrial reads (out of total)": [
+                19468782, 
+                0.0379917246817
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                6617374, 
+                0.146169011217
+            ], 
+            "Final reads (after all filters)": [
+                131148432, 
+                0.254858347066
+            ], 
+            "NRF": [
+                0.767847, 
+                "out of range [0.8, inf]"
+            ], 
+            "PBC1": [
+                0.778956, 
+                "out of range [0.8, inf]"
+            ], 
+            "PBC2": [
+                4.538339, 
+                "OK"
+            ], 
+            "picard_est_library_size": 218616540, 
+            "Fraction of reads in NFR": [
+                0.446735549925, 
+                "OK"
+            ], 
+            "NFR / mono-nuc reads": [
+                1.74038662697, 
+                "out of range [2.5, inf]"
+            ], 
+            "Presence of NFR peak": "OK", 
+            "Presence of Mono-Nuc peak": "OK", 
+            "Presence of Di-Nuc peak": "OK", 
+            "Naive overlap peaks": [
+                276203, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                198674, 
+                "OK"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 291.0, 
+            "Naive peak stats: 50 percentile (median)": 514.0, 
+            "Naive peak stats: 75 percentile": 797.0, 
+            "Naive peak stats: Max size": 3287.0, 
+            "Naive peak stats: Mean": 585.536753764, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 421.0, 
+            "IDR peak stats: 50 percentile (median)": 633.0, 
+            "IDR peak stats: 75 percentile": 895.0, 
+            "IDR peak stats: Max size": 3287.0, 
+            "IDR peak stats: Mean": 686.686803507, 
+            "TSS_enrichment": 18.8838571814, 
+            "Fraction of reads in universal DHS regions": [
+                62441135, 
+                0.482743202865
+            ], 
+            "Fraction of reads in blacklist regions": [
+                1946, 
+                1.50448622174e-05
+            ], 
+            "Fraction of reads in promoter regions": [
+                20879540, 
+                0.161423331173
+            ], 
+            "Fraction of reads in enhancer regions": [
+                52593430, 
+                0.406608894087
+            ], 
+            "Fraction of reads in called peak regions": [
+                41179432, 
+                0.318365303511
+            ]
+        }, 
+        "rep2": {
+            "Genome": "GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz", 
+            "Paired/Single-ended": "Paired-ended", 
+            "Read length": 76, 
+            "Read count from sequencer": 656853982, 
+            "Read count successfully aligned": 655653211, 
+            "Read count after filtering for mapping quality": 434157523, 
+            "Read count after removing duplicate reads": 413972242, 
+            "Read count after removing mitochondrial reads (final read count)": 170697252, 
+            "Mapping quality > q30 (out of total)": [
+                434157523, 
+                0.660965046871
+            ], 
+            "Duplicates (after filtering)": [
+                20185281, 
+                0.191268
+            ], 
+            "Mitochondrial reads (out of total)": [
+                28085630, 
+                0.0428361053203
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                10082272, 
+                0.249743166815
+            ], 
+            "Final reads (after all filters)": [
+                170697252, 
+                0.259870925164
+            ], 
+            "NRF": [
+                0.843731, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.861306, 
+                "OK"
+            ], 
+            "PBC2": [
+                7.395528, 
+                "OK"
+            ], 
+            "picard_est_library_size": 367850648, 
+            "Fraction of reads in NFR": [
+                0.495155817938, 
+                "OK"
+            ], 
+            "NFR / mono-nuc reads": [
+                2.13449069082, 
+                "out of range [2.5, inf]"
+            ], 
+            "Presence of NFR peak": "OK", 
+            "Presence of Mono-Nuc peak": "OK", 
+            "Presence of Di-Nuc peak": "OK", 
+            "Naive overlap peaks": [
+                276203, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                198674, 
+                "OK"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 291.0, 
+            "Naive peak stats: 50 percentile (median)": 514.0, 
+            "Naive peak stats: 75 percentile": 797.0, 
+            "Naive peak stats: Max size": 3287.0, 
+            "Naive peak stats: Mean": 585.536753764, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 421.0, 
+            "IDR peak stats: 50 percentile (median)": 633.0, 
+            "IDR peak stats: 75 percentile": 895.0, 
+            "IDR peak stats: Max size": 3287.0, 
+            "IDR peak stats: Mean": 686.686803507, 
+            "TSS_enrichment": 18.1003903739, 
+            "Fraction of reads in universal DHS regions": [
+                75804330, 
+                0.44990907133
+            ], 
+            "Fraction of reads in blacklist regions": [
+                2368, 
+                1.40544040282e-05
+            ], 
+            "Fraction of reads in promoter regions": [
+                24909792, 
+                0.147843024082
+            ], 
+            "Fraction of reads in enhancer regions": [
+                66099292, 
+                0.392308342799
+            ], 
+            "Fraction of reads in called peak regions": [
+                49812923, 
+                0.295646514218
+            ]
+        }
+    }
+}

--- a/test/test_workflow/ref_output/v1.1.6.a/ENCSR356KRQ_subsampled/qc.json
+++ b/test/test_workflow/ref_output/v1.1.6.a/ENCSR356KRQ_subsampled/qc.json
@@ -1,0 +1,454 @@
+{
+    "general": {
+        "date": "2019-01-11 04:05:27", 
+        "pipeline_ver": "v1.1.6", 
+        "peak_caller": "macs2", 
+        "genome": "hg38_google.tsv", 
+        "description": "ATAC-seq on primary keratinocytes in day 0.0 of differentiation", 
+        "title": "ENCSR356KRQ (subsampled 1/400 reads)", 
+        "paired_end": true
+    }, 
+    "flagstat_qc": {
+        "rep1": {
+            "total": 1286827, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 1281533, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 99.59, 
+            "paired": 691166, 
+            "paired_qc_failed": 0, 
+            "read1": 345583, 
+            "read1_qc_failed": 0, 
+            "read2": 345583, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 605666, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 87.63, 
+            "with_itself": 684846, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 1026, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.15, 
+            "diff_chroms": 553, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 1641618, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 1638620, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 99.82, 
+            "paired": 848854, 
+            "paired_qc_failed": 0, 
+            "read1": 424427, 
+            "read1_qc_failed": 0, 
+            "read2": 424427, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 748282, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 88.15, 
+            "with_itself": 844410, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 1446, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.17, 
+            "diff_chroms": 720, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "dup_qc": {
+        "rep1": {
+            "unpaired_reads": 0, 
+            "paired_reads": 220822, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 0, 
+            "paired_dupes": 682, 
+            "paired_opt_dupes": 3, 
+            "dupes_pct": 0.003088
+        }, 
+        "rep2": {
+            "unpaired_reads": 0, 
+            "paired_reads": 264763, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 0, 
+            "paired_dupes": 1312, 
+            "paired_opt_dupes": 4, 
+            "dupes_pct": 0.004955
+        }
+    }, 
+    "pbc_qc": {
+        "rep1": {
+            "total_read_pairs": 210134, 
+            "distinct_read_pairs": 209477, 
+            "one_read_pair": 209023, 
+            "two_read_pair": 357, 
+            "NRF": 0.996873, 
+            "PBC1": 0.997833, 
+            "PBC2": 585.498599
+        }, 
+        "rep2": {
+            "total_read_pairs": 249549, 
+            "distinct_read_pairs": 248592, 
+            "one_read_pair": 248018, 
+            "two_read_pair": 416, 
+            "NRF": 0.996165, 
+            "PBC1": 0.997691, 
+            "PBC2": 596.197115
+        }
+    }, 
+    "nodup_flagstat_qc": {
+        "rep1": {
+            "total": 440280, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 440280, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 440280, 
+            "paired_qc_failed": 0, 
+            "read1": 220140, 
+            "read1_qc_failed": 0, 
+            "read2": 220140, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 440280, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 100.0, 
+            "with_itself": 440280, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 526902, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 526902, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 526902, 
+            "paired_qc_failed": 0, 
+            "read1": 263451, 
+            "read1_qc_failed": 0, 
+            "read2": 263451, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 526902, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 100.0, 
+            "with_itself": 526902, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "overlap_reproducibility_qc": {
+        "Nt": 32588, 
+        "N1": 14546, 
+        "N2": 16009, 
+        "Np": 32823, 
+        "N_opt": 32823, 
+        "N_consv": 32588, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.0072112434, 
+        "self_consistency_ratio": 1.10057747834, 
+        "reproducibility": "pass"
+    }, 
+    "idr_reproducibility_qc": {
+        "Nt": 499, 
+        "N1": 132, 
+        "N2": 157, 
+        "Np": 639, 
+        "N_opt": 639, 
+        "N_consv": 499, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.28056112224, 
+        "self_consistency_ratio": 1.18939393939, 
+        "reproducibility": "pass"
+    }, 
+    "xcor_score": {
+        "rep1": {
+            "num_reads": 209895, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.00855237457383064, 
+            "phantom_peak": 70, 
+            "corr_phantom_peak": 0.009261564, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.00410843, 
+            "NSC": 2.081665, 
+            "RSC": 0.8623771
+        }, 
+        "rep2": {
+            "num_reads": 249245, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.00984122742143778, 
+            "phantom_peak": 65, 
+            "corr_phantom_peak": 0.01161518, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.005227118, 
+            "NSC": 1.882725, 
+            "RSC": 0.7223014
+        }
+    }, 
+    "frip_macs2_qc": {
+        "rep1": {
+            "FRiP": 0.989959265347
+        }, 
+        "rep2": {
+            "FRiP": 0.978581315573
+        }, 
+        "rep1-pr1": {
+            "FRiP": 0.996717421961
+        }, 
+        "rep2-pr1": {
+            "FRiP": 0.995931730098
+        }, 
+        "rep1-pr2": {
+            "FRiP": 0.996707862064
+        }, 
+        "rep2-pr2": {
+            "FRiP": 0.996609747878
+        }, 
+        "pooled": {
+            "FRiP": 0.684160604609
+        }, 
+        "ppr1": {
+            "FRiP": 0.98916457218
+        }, 
+        "ppr2": {
+            "FRiP": 0.989639280565
+        }
+    }, 
+    "overlap_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.212792394477
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.163567498035
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.159447531545
+        }, 
+        "ppr": {
+            "FRiP": 0.214356187655
+        }
+    }, 
+    "idr_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.0147896066559
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.00646751947402
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.00797006961022
+        }, 
+        "ppr": {
+            "FRiP": 0.0168412684584
+        }
+    }, 
+    "ataqc": {
+        "rep1": {
+            "Genome": "GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz", 
+            "Paired/Single-ended": "Paired-ended", 
+            "Read length": 76, 
+            "Read count from sequencer": 1286827, 
+            "Read count successfully aligned": 1281533, 
+            "Read count after filtering for mapping quality": 888079, 
+            "Read count after removing duplicate reads": 887397, 
+            "Read count after removing mitochondrial reads (final read count)": 440280, 
+            "Mapping quality > q30 (out of total)": [
+                888079, 
+                0.690130841209
+            ], 
+            "Duplicates (after filtering)": [
+                682, 
+                0.003088
+            ], 
+            "Mitochondrial reads (out of total)": [
+                48934, 
+                0.0381839562462
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                886, 
+                0.649560117302
+            ], 
+            "Final reads (after all filters)": [
+                440280, 
+                0.342143893468
+            ], 
+            "NRF": [
+                0.996873, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.997833, 
+                "OK"
+            ], 
+            "PBC2": [
+                585.498599, 
+                "OK"
+            ], 
+            "picard_est_library_size": 51268130, 
+            "Fraction of reads in NFR": [
+                0.194369567086, 
+                "out of range [0.4, inf]"
+            ], 
+            "NFR / mono-nuc reads": [
+                1.37730649413, 
+                "out of range [2.5, inf]"
+            ], 
+            "Presence of NFR peak": "OK", 
+            "Presence of Mono-Nuc peak": "OK", 
+            "Presence of Di-Nuc peak": "OK", 
+            "Naive overlap peaks": [
+                32823, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                639, 
+                "out of range [10000, inf]"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 141.0, 
+            "Naive peak stats: 50 percentile (median)": 209.0, 
+            "Naive peak stats: 75 percentile": 293.0, 
+            "Naive peak stats: Max size": 1206.0, 
+            "Naive peak stats: Mean": 231.782225878, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 186.0, 
+            "IDR peak stats: 50 percentile (median)": 337.0, 
+            "IDR peak stats: 75 percentile": 451.5, 
+            "IDR peak stats: Max size": 819.0, 
+            "IDR peak stats: Mean": 333.9342723, 
+            "TSS_enrichment": 20.3977388654, 
+            "Fraction of reads in universal DHS regions": [
+                207705, 
+                0.494783105839
+            ], 
+            "Fraction of reads in blacklist regions": [
+                8, 
+                1.90571476214e-05
+            ], 
+            "Fraction of reads in promoter regions": [
+                69869, 
+                0.166437980895
+            ], 
+            "Fraction of reads in enhancer regions": [
+                170294, 
+                0.40566473713
+            ], 
+            "Fraction of reads in called peak regions": [
+                2715, 
+                0.00646751947402
+            ]
+        }, 
+        "rep2": {
+            "Genome": "GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz", 
+            "Paired/Single-ended": "Paired-ended", 
+            "Read length": 76, 
+            "Read count from sequencer": 1641618, 
+            "Read count successfully aligned": 1638620, 
+            "Read count after filtering for mapping quality": 1084992, 
+            "Read count after removing duplicate reads": 1083680, 
+            "Read count after removing mitochondrial reads (final read count)": 526902, 
+            "Mapping quality > q30 (out of total)": [
+                1084992, 
+                0.660928425492
+            ], 
+            "Duplicates (after filtering)": [
+                1312, 
+                0.004955
+            ], 
+            "Mitochondrial reads (out of total)": [
+                69935, 
+                0.0426792056731
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                2016, 
+                0.768292682927
+            ], 
+            "Final reads (after all filters)": [
+                526902, 
+                0.320965047898
+            ], 
+            "NRF": [
+                0.996165, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.997691, 
+                "OK"
+            ], 
+            "PBC2": [
+                596.197115, 
+                "OK"
+            ], 
+            "picard_est_library_size": 40892504, 
+            "Fraction of reads in NFR": [
+                0.229200264621, 
+                "out of range [0.4, inf]"
+            ], 
+            "NFR / mono-nuc reads": [
+                1.62168563721, 
+                "out of range [2.5, inf]"
+            ], 
+            "Presence of NFR peak": "OK", 
+            "Presence of Mono-Nuc peak": "OK", 
+            "Presence of Di-Nuc peak": "OK", 
+            "Naive overlap peaks": [
+                32823, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                639, 
+                "out of range [10000, inf]"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 141.0, 
+            "Naive peak stats: 50 percentile (median)": 209.0, 
+            "Naive peak stats: 75 percentile": 293.0, 
+            "Naive peak stats: Max size": 1206.0, 
+            "Naive peak stats: Mean": 231.782225878, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 186.0, 
+            "IDR peak stats: 50 percentile (median)": 337.0, 
+            "IDR peak stats: 75 percentile": 451.5, 
+            "IDR peak stats: Max size": 819.0, 
+            "IDR peak stats: Mean": 333.9342723, 
+            "TSS_enrichment": 17.8908961998, 
+            "Fraction of reads in universal DHS regions": [
+                229492, 
+                0.460374330478
+            ], 
+            "Fraction of reads in blacklist regions": [
+                8, 
+                1.60484663684e-05
+            ], 
+            "Fraction of reads in promoter regions": [
+                74604, 
+                0.149659973119
+            ], 
+            "Fraction of reads in enhancer regions": [
+                194866, 
+                0.390912555919
+            ], 
+            "Fraction of reads in called peak regions": [
+                3973, 
+                0.00797006961022
+            ]
+        }
+    }
+}

--- a/test/test_workflow/ref_output/v1.1.6.a/ENCSR356KRQ_subsampled_chr19_only/qc.json
+++ b/test/test_workflow/ref_output/v1.1.6.a/ENCSR356KRQ_subsampled_chr19_only/qc.json
@@ -1,0 +1,262 @@
+{
+    "general": {
+        "date": "2019-01-16 11:20:14", 
+        "pipeline_ver": "v1.1.6", 
+        "peak_caller": "macs2", 
+        "genome": "hg38_chr19_chrM_google.tsv", 
+        "description": "ATAC-seq on primary keratinocytes in day 0.0 of differentiation", 
+        "title": "ENCSR356KRQ (subsampled 1/400 reads)", 
+        "paired_end": true
+    }, 
+    "flagstat_qc": {
+        "rep1": {
+            "total": 964177, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 444063, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 46.06, 
+            "paired": 691166, 
+            "paired_qc_failed": 0, 
+            "read1": 345583, 
+            "read1_qc_failed": 0, 
+            "read2": 345583, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 142664, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 20.64, 
+            "with_itself": 160458, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 10594, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 1.53, 
+            "diff_chroms": 15, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 1207118, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 587723, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 48.69, 
+            "paired": 848854, 
+            "paired_qc_failed": 0, 
+            "read1": 424427, 
+            "read1_qc_failed": 0, 
+            "read2": 424427, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 193684, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 22.82, 
+            "with_itself": 217106, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 12353, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 1.46, 
+            "diff_chroms": 25, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "dup_qc": {
+        "rep1": {
+            "unpaired_reads": 0, 
+            "paired_reads": 32733, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 0, 
+            "paired_dupes": 968, 
+            "paired_opt_dupes": 1, 
+            "dupes_pct": 0.029573
+        }, 
+        "rep2": {
+            "unpaired_reads": 0, 
+            "paired_reads": 45283, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 0, 
+            "paired_dupes": 2076, 
+            "paired_opt_dupes": 0, 
+            "dupes_pct": 0.045845
+        }
+    }, 
+    "pbc_qc": {
+        "rep1": {
+            "total_read_pairs": 11363, 
+            "distinct_read_pairs": 11309, 
+            "one_read_pair": 11273, 
+            "two_read_pair": 29, 
+            "NRF": 0.995248, 
+            "PBC1": 0.996817, 
+            "PBC2": 388.724138
+        }, 
+        "rep2": {
+            "total_read_pairs": 14660, 
+            "distinct_read_pairs": 14585, 
+            "one_read_pair": 14543, 
+            "two_read_pair": 32, 
+            "NRF": 0.994884, 
+            "PBC1": 0.99712, 
+            "PBC2": 454.46875
+        }
+    }, 
+    "nodup_flagstat_qc": {
+        "rep1": {
+            "total": 63530, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 63530, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 63530, 
+            "paired_qc_failed": 0, 
+            "read1": 31765, 
+            "read1_qc_failed": 0, 
+            "read2": 31765, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 63530, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 100.0, 
+            "with_itself": 63530, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 86414, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 86414, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 86414, 
+            "paired_qc_failed": 0, 
+            "read1": 43207, 
+            "read1_qc_failed": 0, 
+            "read2": 43207, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 86414, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 100.0, 
+            "with_itself": 86414, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "overlap_reproducibility_qc": {
+        "Nt": 2344, 
+        "N1": 880, 
+        "N2": 1117, 
+        "Np": 2370, 
+        "N_opt": 2370, 
+        "N_consv": 2344, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.01109215017, 
+        "self_consistency_ratio": 1.26931818182, 
+        "reproducibility": "pass"
+    }, 
+    "idr_reproducibility_qc": {
+        "Nt": 60, 
+        "N1": 10, 
+        "N2": 16, 
+        "Np": 72, 
+        "N_opt": 72, 
+        "N_consv": 60, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.2, 
+        "self_consistency_ratio": 1.6, 
+        "reproducibility": "pass"
+    }, 
+    "xcor_score": {
+        "rep1": {
+            "num_reads": 11350, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.0121273857082399, 
+            "phantom_peak": 50, 
+            "corr_phantom_peak": 0.01655653, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.007868595, 
+            "NSC": 1.541239, 
+            "RSC": 0.4901961
+        }, 
+        "rep2": {
+            "num_reads": 14653, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.0163692358101201, 
+            "phantom_peak": 40, 
+            "corr_phantom_peak": 0.02083958, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.01084705, 
+            "NSC": 1.509096, 
+            "RSC": 0.5526316
+        }
+    }, 
+    "frip_macs2_qc": {
+        "rep1": {
+            "FRiP": 0.951497797357
+        }, 
+        "rep2": {
+            "FRiP": 0.936941240702
+        }, 
+        "rep1-pr1": {
+            "FRiP": 0.981233480176
+        }, 
+        "rep2-pr1": {
+            "FRiP": 0.972498976389
+        }, 
+        "rep1-pr2": {
+            "FRiP": 0.981762114537
+        }, 
+        "rep2-pr2": {
+            "FRiP": 0.977477477477
+        }, 
+        "pooled": {
+            "FRiP": 0.876610391109
+        }, 
+        "ppr1": {
+            "FRiP": 0.942355022304
+        }, 
+        "ppr2": {
+            "FRiP": 0.950311514499
+        }
+    }, 
+    "overlap_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.264007999077
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.191233480176
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.189824609295
+        }, 
+        "ppr": {
+            "FRiP": 0.267353766873
+        }
+    }, 
+    "idr_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.0273622274353
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.00863436123348
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.0112263700266
+        }, 
+        "ppr": {
+            "FRiP": 0.0309002807368
+        }
+    }
+}

--- a/test/test_workflow/ref_output/v1.1.6.a/ENCSR889WQX/qc.json
+++ b/test/test_workflow/ref_output/v1.1.6.a/ENCSR889WQX/qc.json
@@ -1,0 +1,434 @@
+{
+    "general": {
+        "date": "2019-01-11 13:01:14", 
+        "pipeline_ver": "v1.1.6", 
+        "peak_caller": "macs2", 
+        "genome": "mm10_google.tsv", 
+        "description": "ATAC-seq on Mus musculus C57BL/6 frontal cortex adult", 
+        "title": "ENCSR889WQX", 
+        "paired_end": false
+    }, 
+    "flagstat_qc": {
+        "rep1": {
+            "total": 141785320, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 129935211, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 91.64, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 120504492, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 119273855, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 98.98, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "dup_qc": {
+        "rep1": {
+            "unpaired_reads": 55527625, 
+            "paired_reads": 0, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 25590151, 
+            "paired_dupes": 0, 
+            "paired_opt_dupes": 0, 
+            "dupes_pct": 0.460854
+        }, 
+        "rep2": {
+            "unpaired_reads": 53570813, 
+            "paired_reads": 0, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 15110687, 
+            "paired_dupes": 0, 
+            "paired_opt_dupes": 0, 
+            "dupes_pct": 0.282069
+        }
+    }, 
+    "pbc_qc": {
+        "rep1": {
+            "total_read_pairs": 38074482, 
+            "distinct_read_pairs": 32217704, 
+            "one_read_pair": 30277193, 
+            "two_read_pair": 1547993, 
+            "NRF": 0.846176, 
+            "PBC1": 0.939769, 
+            "PBC2": 19.558999
+        }, 
+        "rep2": {
+            "total_read_pairs": 47500660, 
+            "distinct_read_pairs": 40037045, 
+            "one_read_pair": 35874186, 
+            "two_read_pair": 3134862, 
+            "NRF": 0.842873, 
+            "PBC1": 0.896025, 
+            "PBC2": 11.443625
+        }
+    }, 
+    "nodup_flagstat_qc": {
+        "rep1": {
+            "total": 29937474, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 29937474, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 38460126, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 38460126, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "overlap_reproducibility_qc": {
+        "Nt": 248249, 
+        "N1": 213469, 
+        "N2": 231341, 
+        "Np": 254200, 
+        "N_opt": 254200, 
+        "N_consv": 248249, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.02397189918, 
+        "self_consistency_ratio": 1.08372175819, 
+        "reproducibility": "pass"
+    }, 
+    "idr_reproducibility_qc": {
+        "Nt": 122878, 
+        "N1": 100429, 
+        "N2": 101843, 
+        "Np": 135019, 
+        "N_opt": 135019, 
+        "N_consv": 122878, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.0988053191, 
+        "self_consistency_ratio": 1.01407959852, 
+        "reproducibility": "pass"
+    }, 
+    "xcor_score": {
+        "rep1": {
+            "num_reads": 25000000, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.377266901214234, 
+            "phantom_peak": 45, 
+            "corr_phantom_peak": 0.3481357, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.2804898, 
+            "NSC": 1.345029, 
+            "RSC": 1.430643
+        }, 
+        "rep2": {
+            "num_reads": 25000000, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.380719933195802, 
+            "phantom_peak": 45, 
+            "corr_phantom_peak": 0.350552, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.2865114, 
+            "NSC": 1.328812, 
+            "RSC": 1.471074
+        }
+    }, 
+    "frip_macs2_qc": {
+        "rep1": {
+            "FRiP": 0.275468961911
+        }, 
+        "rep2": {
+            "FRiP": 0.279349387412
+        }, 
+        "rep1-pr1": {
+            "FRiP": 0.2780963858
+        }, 
+        "rep2-pr1": {
+            "FRiP": 0.280574979843
+        }, 
+        "rep1-pr2": {
+            "FRiP": 0.273888000193
+        }, 
+        "rep2-pr2": {
+            "FRiP": 0.279871239297
+        }, 
+        "pooled": {
+            "FRiP": 0.285776581603
+        }, 
+        "ppr1": {
+            "FRiP": 0.276928429095
+        }, 
+        "ppr2": {
+            "FRiP": 0.273568113301
+        }
+    }, 
+    "overlap_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.259934108468
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.240030689001
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.247021224881
+        }, 
+        "ppr": {
+            "FRiP": 0.263751633968
+        }
+    }, 
+    "idr_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.169180239225
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.152927559512
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.147487023555
+        }, 
+        "ppr": {
+            "FRiP": 0.180044734176
+        }
+    }, 
+    "ataqc": {
+        "rep1": {
+            "Genome": "mm10_no_alt_analysis_set_ENCODE.fasta.gz", 
+            "Paired/Single-ended": "Single-ended", 
+            "Read length": 50, 
+            "Read count from sequencer": 141785320, 
+            "Read count successfully aligned": 129935211, 
+            "Read count after filtering for mapping quality": 86224763, 
+            "Read count after removing duplicate reads": 60634612, 
+            "Read count after removing mitochondrial reads (final read count)": 29937474, 
+            "bowtie_stats": 79937574, 
+            "Mapping quality > q30 (out of total)": [
+                86224763, 
+                0.608136039754
+            ], 
+            "Duplicates (after filtering)": [
+                25590151, 
+                0.460854
+            ], 
+            "Mitochondrial reads (out of total)": [
+                23426656, 
+                0.180294900972
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                17422149, 
+                0.680814622782
+            ], 
+            "Final reads (after all filters)": [
+                29937474, 
+                0.211146499511
+            ], 
+            "NRF": [
+                0.846176, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.939769, 
+                "OK"
+            ], 
+            "PBC2": [
+                19.558999, 
+                "OK"
+            ], 
+            "picard_est_library_size": 0, 
+            "Naive overlap peaks": [
+                254200, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                135019, 
+                "OK"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 277.0, 
+            "Naive peak stats: 50 percentile (median)": 448.0, 
+            "Naive peak stats: 75 percentile": 703.0, 
+            "Naive peak stats: Max size": 2215.0, 
+            "Naive peak stats: Mean": 530.36763572, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 431.0, 
+            "IDR peak stats: 50 percentile (median)": 633.0, 
+            "IDR peak stats: 75 percentile": 896.0, 
+            "IDR peak stats: Max size": 2215.0, 
+            "IDR peak stats: Mean": 689.452203023, 
+            "TSS_enrichment": 13.4139630724, 
+            "Fraction of reads in universal DHS regions": [
+                16522326, 
+                0.552466421993
+            ], 
+            "Fraction of reads in blacklist regions": [
+                10652, 
+                0.000356176989067
+            ], 
+            "Fraction of reads in promoter regions": [
+                3230332, 
+                0.10801445038
+            ], 
+            "Fraction of reads in enhancer regions": [
+                13300481, 
+                0.444735756264
+            ], 
+            "Fraction of reads in called peak regions": [
+                4573525, 
+                0.152927559512
+            ]
+        }, 
+        "rep2": {
+            "Genome": "mm10_no_alt_analysis_set_ENCODE.fasta.gz", 
+            "Paired/Single-ended": "Single-ended", 
+            "Read length": 50, 
+            "Read count from sequencer": 120504492, 
+            "Read count successfully aligned": 119273855, 
+            "Read count after filtering for mapping quality": 88974415, 
+            "Read count after removing duplicate reads": 73863728, 
+            "Read count after removing mitochondrial reads (final read count)": 38460126, 
+            "bowtie_stats": 67703560, 
+            "Mapping quality > q30 (out of total)": [
+                88974415, 
+                0.738349363773
+            ], 
+            "Duplicates (after filtering)": [
+                15110687, 
+                0.282069
+            ], 
+            "Mitochondrial reads (out of total)": [
+                8174188, 
+                0.0685329404336
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                6041008, 
+                0.399783808638
+            ], 
+            "Final reads (after all filters)": [
+                38460126, 
+                0.319159272502
+            ], 
+            "NRF": [
+                0.842873, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.896025, 
+                "OK"
+            ], 
+            "PBC2": [
+                11.443625, 
+                "OK"
+            ], 
+            "picard_est_library_size": 0, 
+            "Naive overlap peaks": [
+                254200, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                135019, 
+                "OK"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 277.0, 
+            "Naive peak stats: 50 percentile (median)": 448.0, 
+            "Naive peak stats: 75 percentile": 703.0, 
+            "Naive peak stats: Max size": 2215.0, 
+            "Naive peak stats: Mean": 530.36763572, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 431.0, 
+            "IDR peak stats: 50 percentile (median)": 633.0, 
+            "IDR peak stats: 75 percentile": 896.0, 
+            "IDR peak stats: Max size": 2215.0, 
+            "IDR peak stats: Mean": 689.452203023, 
+            "TSS_enrichment": 10.6781726793, 
+            "Fraction of reads in universal DHS regions": [
+                21943761, 
+                0.570991435269
+            ], 
+            "Fraction of reads in blacklist regions": [
+                12261, 
+                0.000319039474949
+            ], 
+            "Fraction of reads in promoter regions": [
+                4713232, 
+                0.122641469912
+            ], 
+            "Fraction of reads in enhancer regions": [
+                17254753, 
+                0.448980290147
+            ], 
+            "Fraction of reads in called peak regions": [
+                5668071, 
+                0.147487023555
+            ]
+        }
+    }
+}

--- a/test/test_workflow/ref_output/v1.1.6.a/ENCSR889WQX_subsampled/qc.json
+++ b/test/test_workflow/ref_output/v1.1.6.a/ENCSR889WQX_subsampled/qc.json
@@ -1,0 +1,434 @@
+{
+    "general": {
+        "date": "2019-01-11 04:17:12", 
+        "pipeline_ver": "v1.1.6", 
+        "peak_caller": "macs2", 
+        "genome": "mm10_google.tsv", 
+        "description": "ATAC-seq on Mus musculus C57BL/6 frontal cortex adult", 
+        "title": "ENCSR889WQX (subsampled 1/400 reads)", 
+        "paired_end": false
+    }, 
+    "flagstat_qc": {
+        "rep1": {
+            "total": 356699, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 326957, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 91.66, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 301254, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 298157, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 98.97, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "dup_qc": {
+        "rep1": {
+            "unpaired_reads": 139121, 
+            "paired_reads": 0, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 36851, 
+            "paired_dupes": 0, 
+            "paired_opt_dupes": 0, 
+            "dupes_pct": 0.264885
+        }, 
+        "rep2": {
+            "unpaired_reads": 134177, 
+            "paired_reads": 0, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 9251, 
+            "paired_dupes": 0, 
+            "paired_opt_dupes": 0, 
+            "dupes_pct": 0.068946
+        }
+    }, 
+    "pbc_qc": {
+        "rep1": {
+            "total_read_pairs": 95203, 
+            "distinct_read_pairs": 92035, 
+            "one_read_pair": 90553, 
+            "two_read_pair": 815, 
+            "NRF": 0.966724, 
+            "PBC1": 0.983897, 
+            "PBC2": 111.107975
+        }, 
+        "rep2": {
+            "total_read_pairs": 118878, 
+            "distinct_read_pairs": 117806, 
+            "one_read_pair": 117144, 
+            "two_read_pair": 440, 
+            "NRF": 0.990982, 
+            "PBC1": 0.994381, 
+            "PBC2": 266.236364
+        }
+    }, 
+    "nodup_flagstat_qc": {
+        "rep1": {
+            "total": 102270, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 102270, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 124926, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 124926, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "overlap_reproducibility_qc": {
+        "Nt": 116400, 
+        "N1": 45966, 
+        "N2": 64625, 
+        "Np": 113320, 
+        "N_opt": 116400, 
+        "N_consv": 116400, 
+        "opt_set": "rep1-rep2", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.0271796682, 
+        "self_consistency_ratio": 1.40593047035, 
+        "reproducibility": "pass"
+    }, 
+    "idr_reproducibility_qc": {
+        "Nt": 75, 
+        "N1": 39, 
+        "N2": 29, 
+        "Np": 101, 
+        "N_opt": 101, 
+        "N_consv": 75, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.34666666667, 
+        "self_consistency_ratio": 1.34482758621, 
+        "reproducibility": "pass"
+    }, 
+    "xcor_score": {
+        "rep1": {
+            "num_reads": 89776, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.0493311358183571, 
+            "phantom_peak": 40, 
+            "corr_phantom_peak": 0.04961571, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.02846737, 
+            "NSC": 1.732901, 
+            "RSC": 0.9865438
+        }, 
+        "rep2": {
+            "num_reads": 117515, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.0187798702155508, 
+            "phantom_peak": 40, 
+            "corr_phantom_peak": 0.01772723, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.01020629, 
+            "NSC": 1.840029, 
+            "RSC": 1.139961
+        }
+    }, 
+    "frip_macs2_qc": {
+        "rep1": {
+            "FRiP": 0.97891418642
+        }, 
+        "rep2": {
+            "FRiP": 0.993124282007
+        }, 
+        "rep1-pr1": {
+            "FRiP": 0.967942434504
+        }, 
+        "rep2-pr1": {
+            "FRiP": 0.989771605569
+        }, 
+        "rep1-pr2": {
+            "FRiP": 0.972932632329
+        }, 
+        "rep2-pr2": {
+            "FRiP": 0.988341814592
+        }, 
+        "pooled": {
+            "FRiP": 0.986714329132
+        }, 
+        "ppr1": {
+            "FRiP": 0.985498716786
+        }, 
+        "ppr2": {
+            "FRiP": 0.984533744995
+        }
+    }, 
+    "overlap_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.784587849931
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.910399215826
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.852223120453
+        }, 
+        "ppr": {
+            "FRiP": 0.768798452417
+        }
+    }, 
+    "idr_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.0162573387171
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.0229459989307
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.00702038037697
+        }, 
+        "ppr": {
+            "FRiP": 0.0173041762546
+        }
+    }, 
+    "ataqc": {
+        "rep1": {
+            "Genome": "mm10_no_alt_analysis_set_ENCODE.fasta.gz", 
+            "Paired/Single-ended": "Single-ended", 
+            "Read length": 100, 
+            "Read count from sequencer": 356699, 
+            "Read count successfully aligned": 326957, 
+            "Read count after filtering for mapping quality": 217313, 
+            "Read count after removing duplicate reads": 180462, 
+            "Read count after removing mitochondrial reads (final read count)": 102270, 
+            "bowtie_stats": 200680, 
+            "Mapping quality > q30 (out of total)": [
+                217313, 
+                0.609233555463
+            ], 
+            "Duplicates (after filtering)": [
+                36851, 
+                0.264885
+            ], 
+            "Mitochondrial reads (out of total)": [
+                58673, 
+                0.179451732185
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                31424, 
+                0.852731269165
+            ], 
+            "Final reads (after all filters)": [
+                102270, 
+                0.286712326079
+            ], 
+            "NRF": [
+                0.966724, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.983897, 
+                "OK"
+            ], 
+            "PBC2": [
+                111.107975, 
+                "OK"
+            ], 
+            "picard_est_library_size": 0, 
+            "Naive overlap peaks": [
+                116400, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                101, 
+                "out of range [10000, inf]"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 73.0, 
+            "Naive peak stats: 50 percentile (median)": 73.0, 
+            "Naive peak stats: 75 percentile": 3371.25, 
+            "Naive peak stats: Max size": 89214999.0, 
+            "Naive peak stats: Mean": 16528.6690636, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 149.0, 
+            "IDR peak stats: 50 percentile (median)": 249.0, 
+            "IDR peak stats: 75 percentile": 362.0, 
+            "IDR peak stats: Max size": 37679.0, 
+            "IDR peak stats: Mean": 837.693069307, 
+            "TSS_enrichment": 29.0727191985, 
+            "Fraction of reads in universal DHS regions": [
+                51764, 
+                0.576590625557
+            ], 
+            "Fraction of reads in blacklist regions": [
+                240, 
+                0.00267332026377
+            ], 
+            "Fraction of reads in promoter regions": [
+                12150, 
+                0.135336838353
+            ], 
+            "Fraction of reads in enhancer regions": [
+                39516, 
+                0.440162181429
+            ], 
+            "Fraction of reads in called peak regions": [
+                2060, 
+                0.0229459989307
+            ]
+        }, 
+        "rep2": {
+            "Genome": "mm10_no_alt_analysis_set_ENCODE.fasta.gz", 
+            "Paired/Single-ended": "Single-ended", 
+            "Read length": 50, 
+            "Read count from sequencer": 301254, 
+            "Read count successfully aligned": 298157, 
+            "Read count after filtering for mapping quality": 222881, 
+            "Read count after removing duplicate reads": 213630, 
+            "Read count after removing mitochondrial reads (final read count)": 124926, 
+            "bowtie_stats": 169465, 
+            "Mapping quality > q30 (out of total)": [
+                222881, 
+                0.739844118252
+            ], 
+            "Duplicates (after filtering)": [
+                9251, 
+                0.068946
+            ], 
+            "Mitochondrial reads (out of total)": [
+                20535, 
+                0.0688731104754
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                7888, 
+                0.852664576803
+            ], 
+            "Final reads (after all filters)": [
+                124926, 
+                0.41468660997
+            ], 
+            "NRF": [
+                0.990982, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.994381, 
+                "OK"
+            ], 
+            "PBC2": [
+                266.236364, 
+                "OK"
+            ], 
+            "picard_est_library_size": 0, 
+            "Naive overlap peaks": [
+                116400, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                101, 
+                "out of range [10000, inf]"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 73.0, 
+            "Naive peak stats: 50 percentile (median)": 73.0, 
+            "Naive peak stats: 75 percentile": 3371.25, 
+            "Naive peak stats: Max size": 89214999.0, 
+            "Naive peak stats: Mean": 16528.6690636, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 149.0, 
+            "IDR peak stats: 50 percentile (median)": 249.0, 
+            "IDR peak stats: 75 percentile": 362.0, 
+            "IDR peak stats: Max size": 37679.0, 
+            "IDR peak stats: Mean": 837.693069307, 
+            "TSS_enrichment": 17.9595743429, 
+            "Fraction of reads in universal DHS regions": [
+                71565, 
+                0.608986086883
+            ], 
+            "Fraction of reads in blacklist regions": [
+                154, 
+                0.0013104710037
+            ], 
+            "Fraction of reads in promoter regions": [
+                18766, 
+                0.159690252308
+            ], 
+            "Fraction of reads in enhancer regions": [
+                52846, 
+                0.449695783517
+            ], 
+            "Fraction of reads in called peak regions": [
+                825, 
+                0.00702038037697
+            ]
+        }
+    }
+}

--- a/test/test_workflow/ref_output/v1.1.6.a/ENCSR889WQX_subsampled_chr19_only/qc.json
+++ b/test/test_workflow/ref_output/v1.1.6.a/ENCSR889WQX_subsampled_chr19_only/qc.json
@@ -1,0 +1,262 @@
+{
+    "general": {
+        "date": "2019-01-16 11:20:59", 
+        "pipeline_ver": "v1.1.6", 
+        "peak_caller": "macs2", 
+        "genome": "mm10_chr19_chrM_google.tsv", 
+        "description": "ATAC-seq on Mus musculus C57BL/6 frontal cortex adult", 
+        "title": "ENCSR889WQX (subsampled 1/400 reads)", 
+        "paired_end": false
+    }, 
+    "flagstat_qc": {
+        "rep1": {
+            "total": 241186, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 118495, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 49.13, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 213743, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 86974, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 40.69, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "dup_qc": {
+        "rep1": {
+            "unpaired_reads": 65292, 
+            "paired_reads": 0, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 44202, 
+            "paired_dupes": 0, 
+            "paired_opt_dupes": 0, 
+            "dupes_pct": 0.67699
+        }, 
+        "rep2": {
+            "unpaired_reads": 28860, 
+            "paired_reads": 0, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 11886, 
+            "paired_dupes": 0, 
+            "paired_opt_dupes": 0, 
+            "dupes_pct": 0.41185
+        }
+    }, 
+    "pbc_qc": {
+        "rep1": {
+            "total_read_pairs": 6678, 
+            "distinct_read_pairs": 6386, 
+            "one_read_pair": 6318, 
+            "two_read_pair": 32, 
+            "NRF": 0.956274, 
+            "PBC1": 0.989352, 
+            "PBC2": 197.4375
+        }, 
+        "rep2": {
+            "total_read_pairs": 8337, 
+            "distinct_read_pairs": 7831, 
+            "one_read_pair": 7759, 
+            "two_read_pair": 31, 
+            "NRF": 0.939307, 
+            "PBC1": 0.990806, 
+            "PBC2": 250.290323
+        }
+    }, 
+    "nodup_flagstat_qc": {
+        "rep1": {
+            "total": 21090, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 21090, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 16974, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 16974, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "overlap_reproducibility_qc": {
+        "Nt": 6782, 
+        "N1": 4066, 
+        "N2": 4786, 
+        "Np": 6499, 
+        "N_opt": 6782, 
+        "N_consv": 6782, 
+        "opt_set": "rep1-rep2", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.04354516079, 
+        "self_consistency_ratio": 1.17707820954, 
+        "reproducibility": "pass"
+    }, 
+    "idr_reproducibility_qc": {
+        "Nt": 6, 
+        "N1": 1, 
+        "N2": 2, 
+        "Np": 5, 
+        "N_opt": 6, 
+        "N_consv": 6, 
+        "opt_set": "rep1-rep2", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.2, 
+        "self_consistency_ratio": 2.0, 
+        "reproducibility": "pass"
+    }, 
+    "xcor_score": {
+        "rep1": {
+            "num_reads": 6294, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.0115227391406977, 
+            "phantom_peak": 45, 
+            "corr_phantom_peak": 0.02620779, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.004486151, 
+            "NSC": 2.568514, 
+            "RSC": 0.3239437
+        }, 
+        "rep2": {
+            "num_reads": 7767, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.0139132150749603, 
+            "phantom_peak": 40, 
+            "corr_phantom_peak": 0.01743494, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.005612001, 
+            "NSC": 2.47919, 
+            "RSC": 0.7021277
+        }
+    }, 
+    "frip_macs2_qc": {
+        "rep1": {
+            "FRiP": 0.998728948205
+        }, 
+        "rep2": {
+            "FRiP": 0.99729625338
+        }, 
+        "rep1-pr1": {
+            "FRiP": 0.997775659358
+        }, 
+        "rep2-pr1": {
+            "FRiP": 0.998455200824
+        }, 
+        "rep1-pr2": {
+            "FRiP": 0.998728948205
+        }, 
+        "rep2-pr2": {
+            "FRiP": 0.998454802987
+        }, 
+        "pooled": {
+            "FRiP": 0.993883792049
+        }, 
+        "ppr1": {
+            "FRiP": 0.998719954487
+        }, 
+        "ppr2": {
+            "FRiP": 0.997155049787
+        }
+    }, 
+    "overlap_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.576772633525
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.814108674929
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.734775331531
+        }, 
+        "ppr": {
+            "FRiP": 0.552592276509
+        }
+    }, 
+    "idr_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.0134414337529
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.013981569749
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.00952748809064
+        }, 
+        "ppr": {
+            "FRiP": 0.0131569589645
+        }
+    }
+}

--- a/test/test_workflow/test_atac.sh
+++ b/test/test_workflow/test_atac.sh
@@ -8,7 +8,7 @@ fi
 if [ $# -gt 2 ]; then
   DOCKER_IMAGE=$3
 else
-  DOCKER_IMAGE=quay.io/encode-dcc/atac-seq-pipeline:test-v1.1.7
+  DOCKER_IMAGE=quay.io/encode-dcc/atac-seq-pipeline:test-v1.1.7.1
 fi
 INPUT=$1
 GCLOUD_SERVICE_ACCOUNT_SECRET_JSON_FILE=$2

--- a/utils/resumer/atac.v1.1.6.json
+++ b/utils/resumer/atac.v1.1.6.json
@@ -27,17 +27,11 @@
         "plot_png" : "atac.xcor__plot_png",
         "score" : "atac.xcor__score"
     },
-    "atac.count_signal_track" : {
-        "pos_bw" : "atac.count_signal_track__pos_bw",
-        "neg_bw" : "atac.count_signal_track__neg_bw"
-    },
-    "atac.macs2_signal_track" : {
-        "pval_bw" : "atac.macs2_signal_track__pval_bw",
-        "fc_bw" : "atac.macs2_signal_track__fc_bw"
-    },
     "atac.macs2" : {
         "npeak" : "atac.peaks",
-        "frip_qc" : "atac.macs2__frip_qc"
+        "frip_qc" : "atac.macs2__frip_qc",
+        "sig_pval" : "atac.macs2_signal_track__pval_bw",
+        "sig_fc" : "atac.macs2_signal_track__fc_bw"
     },
     "atac.macs2_pr1" : {
         "npeak" : "atac.peaks_pr1",
@@ -82,17 +76,11 @@
     "atac.pool_ta_pr2" : {
         "ta_pooled" : "atac.pool_ta_pr2__ta_pooled"
     },
-    "atac.count_signal_track_pooled" : {
-        "pos_bw" : "atac.count_signal_track_pooled__pos_bw",
-        "neg_bw" : "atac.count_signal_track_pooled__neg_bw"
-    },
-    "atac.macs2_signal_track_pooled" : {
-        "pval_bw" : "atac.macs2_signal_track_pooled__pval_bw",
-        "fc_bw" : "atac.macs2_signal_track_pooled__fc_bw"
-    },
     "atac.macs2_pooled" : {
         "npeak" : "atac.peak_pooled",
-        "frip_qc" : "atac.macs2_pooled__frip_qc"
+        "frip_qc" : "atac.macs2_pooled__frip_qc",
+        "sig_pval" : "atac.macs2_signal_track_pooled__pval_bw",
+        "sig_fc" : "atac.macs2_signal_track_pooled__fc_bw"
     },
     "atac.macs2_ppr1" : {
         "npeak" : "atac.peak_ppr1",

--- a/workflow_opts/docker.json
+++ b/workflow_opts/docker.json
@@ -1,6 +1,6 @@
 {
     "default_runtime_attributes" : {
-        "docker" : "quay.io/encode-dcc/atac-seq-pipeline:v1.1.7",
+        "docker" : "quay.io/encode-dcc/atac-seq-pipeline:v1.1.7.1",
         "zones": "us-west1-a us-west1-b us-west1-c us-central1-c us-central1-b",
         "failOnStderr" : false,
         "continueOnReturnCode" : 0,

--- a/workflow_opts/docker_test.json
+++ b/workflow_opts/docker_test.json
@@ -1,6 +1,6 @@
 {
     "default_runtime_attributes" : {
-        "docker" : "quay.io/encode-dcc/atac-seq-pipeline:test-v1.1.7",
+        "docker" : "quay.io/encode-dcc/atac-seq-pipeline:test-v1.1.7.1",
         "zones": "us-west1-a us-west1-b us-west1-c us-central1-c us-central1-b",
         "failOnStderr" : false,
         "continueOnReturnCode" : 0,

--- a/workflow_opts/scg.json
+++ b/workflow_opts/scg.json
@@ -1,7 +1,7 @@
 {
     "default_runtime_attributes" : {
         "slurm_account" : "YOUR_SLURM_ACCOUNT",
-        "singularity_container" : "/reference/ENCODE/pipeline_singularity_images/atac-seq-pipeline-v1.1.7.simg",
+        "singularity_container" : "/reference/ENCODE/pipeline_singularity_images/atac-seq-pipeline-v1.1.7.1.simg",
         "singularity_bindpath" : "/reference/ENCODE,/scratch,/srv/gsfs0"
     }
 }

--- a/workflow_opts/scg.json
+++ b/workflow_opts/scg.json
@@ -2,7 +2,6 @@
     "default_runtime_attributes" : {
         "slurm_account" : "YOUR_SLURM_ACCOUNT",
         "singularity_container" : "/reference/ENCODE/pipeline_singularity_images/atac-seq-pipeline-v1.1.7.simg",
-        "singularity_ld_library_path" : "/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib",
         "singularity_bindpath" : "/reference/ENCODE,/scratch,/srv/gsfs0"
     }
 }

--- a/workflow_opts/sge.json
+++ b/workflow_opts/sge.json
@@ -1,7 +1,6 @@
 {
     "default_runtime_attributes" : {
         "sge_pe" : "shm",
-        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg",
-        "singularity_ld_library_path" : "/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib"
+        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg"
     }
 }

--- a/workflow_opts/sge.json
+++ b/workflow_opts/sge.json
@@ -1,6 +1,6 @@
 {
     "default_runtime_attributes" : {
         "sge_pe" : "shm",
-        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg"
+        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.1.simg"
     }
 }

--- a/workflow_opts/sherlock.json
+++ b/workflow_opts/sherlock.json
@@ -1,7 +1,7 @@
 {
     "default_runtime_attributes" : {
         "slurm_partition" : "normal",
-        "singularity_container" : "/home/groups/cherry/encode/pipeline_singularity_images/atac-seq-pipeline-v1.1.7.simg",
+        "singularity_container" : "/home/groups/cherry/encode/pipeline_singularity_images/atac-seq-pipeline-v1.1.7.1.simg",
         "singularity_bindpath" : "/scratch,/lscratch,/oak/stanford,/home/groups/cherry/encode"
     }
 }

--- a/workflow_opts/sherlock.json
+++ b/workflow_opts/sherlock.json
@@ -2,7 +2,6 @@
     "default_runtime_attributes" : {
         "slurm_partition" : "normal",
         "singularity_container" : "/home/groups/cherry/encode/pipeline_singularity_images/atac-seq-pipeline-v1.1.7.simg",
-        "singularity_ld_library_path" : "/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib",
         "singularity_bindpath" : "/scratch,/lscratch,/oak/stanford,/home/groups/cherry/encode"
     }
 }

--- a/workflow_opts/singularity.json
+++ b/workflow_opts/singularity.json
@@ -1,5 +1,5 @@
 {
     "default_runtime_attributes" : {
-        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg"
+        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.1.simg"
     }
 }

--- a/workflow_opts/singularity.json
+++ b/workflow_opts/singularity.json
@@ -1,6 +1,5 @@
 {
     "default_runtime_attributes" : {
-        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg",
-        "singularity_ld_library_path" : "/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib"
+        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg"
     }
 }

--- a/workflow_opts/slurm.json
+++ b/workflow_opts/slurm.json
@@ -2,6 +2,6 @@
     "default_runtime_attributes" : {
         "slurm_partition" : "YOUR_SLURM_PARTITION",
         "slurm_account" : "YOUR_SLURM_ACCOUNT",
-        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg"
+        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.1.simg"
     }
 }

--- a/workflow_opts/slurm.json
+++ b/workflow_opts/slurm.json
@@ -2,7 +2,6 @@
     "default_runtime_attributes" : {
         "slurm_partition" : "YOUR_SLURM_PARTITION",
         "slurm_account" : "YOUR_SLURM_ACCOUNT",
-        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg",
-        "singularity_ld_library_path" : "/opt/intel/compilers_and_libraries_2018.0.128/linux/mkl/lib/intel64_lin:/usr/local/lib"
+        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.1.7.simg"
     }
 }


### PR DESCRIPTION
* bug fixes
  - resumer can work with v1.1.6 workflows which has a rep pair (repX-repY) index starting from zero.
  - update incorrectly-built conda package.
  - remove redundant 'raw peaks' from ataqc qc html/txt.
  - workaround for cromwell-38 wom API bug (https://github.com/broadinstitute/cromwell/issues/4659)
  - fix for singularity backend hanging problem. use built-in background processing in cromwell instead of `& echo $!` to print PID.
  - allow irregular chr names in `*.hammock.gz` (used for Wash U genome browser).