### PR TITLE
fix inflated read counts from multimapping

### DIFF
--- a/atac.wdl
+++ b/atac.wdl
@@ -3,7 +3,7 @@
 
 workflow atac {
 	# pipeline version
-	String pipeline_ver = 'v1.2.0'
+	String pipeline_ver = 'v1.3.0'
 
 	# general sample information
 	String title = 'Untitled'

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -2,8 +2,8 @@
 
 ## Command line for version change
 ```bash
-PREV_VER=v1.2.0
-NEW_VER=v1.2.0
+PREV_VER=v1.3.0
+NEW_VER=v1.3.0
 for f in $(grep -rl ${PREV_VER} --include=*.{wdl,md,sh})
 do
   sed -i "s/${PREV_VER}/${NEW_VER}/g" ${f}
@@ -24,7 +24,7 @@ Run the following command line locally to build out DX workflows for this pipeli
 
 ```bash
 # version
-VER=v1.2.0
+VER=v1.3.0
 
 # general
 java -jar ~/dxWDL-0.77.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras workflow_opts/docker.json -f -folder /ATAC-seq/workflows/$VER/general -defaults examples/dx/template_general.json

--- a/docs/tutorial_dx_web.md
+++ b/docs/tutorial_dx_web.md
@@ -15,8 +15,8 @@ This document describes instruction for the item 2).
 
 3. Move to one of the following workflow directories according to the platform you have chosen for your project (AWS or Azure). These DX workflows are pre-built with all parameters defined.
 
-* [AWS test workflow](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.2.0/test_ENCSR356KRQ_subsampled)
-* [Azure test workflow](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.2.0/test_ENCSR356KRQ_subsampled)
+* [AWS test workflow](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.3.0/test_ENCSR356KRQ_subsampled)
+* [Azure test workflow](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.3.0/test_ENCSR356KRQ_subsampled)
 
 4. Copy it to your project by right-clicking on the DX workflow `atac` and choose "Copy". 
 
@@ -40,16 +40,16 @@ This document describes instruction for the item 2).
 1. DNAnexus allows only one copy of a workflow per project. The example workflow in the previous section is pre-built for the subsampled test sample [ENCSR356KRQ](https://www.encodeproject.org/experiments/ENCSR356KRQ/) with all parameters defined already.
 
 2. Copy one of the following workflows according to the platform you have chosen for your project (AWS or Azure).
-* [AWS general](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.2.0/general) without pre-defined reference genome.
-* [AWS hg38](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.2.0/hg38) with pre-defined hg38 reference genome.
-* [AWS hg19](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.2.0/hg19) with pre-defined hg19 reference genome.
-* [AWS mm10](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.2.0/mm10) with pre-defined mm10 reference genome.
-* [AWS mm9](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.2.0/mm9) with pre-defined mm9 reference genome.
-* [Azure general](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.2.0/general) without pre-defined reference genome.
-* [Azure hg38](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.2.0/hg38) with pre-defined hg38 reference genome.
-* [Azure hg19](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.2.0/hg19) with pre-defined hg19 reference genome.
-* [Azure mm10](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.2.0/mm10) with pre-defined mm10 reference genome.
-* [Azure mm9](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.2.0/mm9) with pre-defined mm9 reference genome.
+* [AWS general](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.3.0/general) without pre-defined reference genome.
+* [AWS hg38](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.3.0/hg38) with pre-defined hg38 reference genome.
+* [AWS hg19](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.3.0/hg19) with pre-defined hg19 reference genome.
+* [AWS mm10](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.3.0/mm10) with pre-defined mm10 reference genome.
+* [AWS mm9](https://platform.DNAnexus.com/projects/BKpvFg00VBPV975PgJ6Q03v6/data/ATAC-seq/workflows/v1.3.0/mm9) with pre-defined mm9 reference genome.
+* [Azure general](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.3.0/general) without pre-defined reference genome.
+* [Azure hg38](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.3.0/hg38) with pre-defined hg38 reference genome.
+* [Azure hg19](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.3.0/hg19) with pre-defined hg19 reference genome.
+* [Azure mm10](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.3.0/mm10) with pre-defined mm10 reference genome.
+* [Azure mm9](https://platform.DNAnexus.com/projects/F6K911Q9xyfgJ36JFzv03Z5J/data/ATAC-seq/workflows/v1.3.0/mm9) with pre-defined mm9 reference genome.
 
 3. Click on the DX workflow `atac`.
 

--- a/docs/tutorial_local_singularity.md
+++ b/docs/tutorial_local_singularity.md
@@ -33,7 +33,7 @@
 
 6. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.2.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.2.0
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.3.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.3.0
     ```
 
 7. Run a pipeline for the test sample.
@@ -53,7 +53,7 @@
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.2.0.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.0.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/tutorial_scg.md
+++ b/docs/tutorial_scg.md
@@ -63,7 +63,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.2.0.simg",
+            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.3.0.simg",
             "singularity_bindpath" : "/reference/ENCODE,/scratch,/srv/gsfs0,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/tutorial_scg_backend.md
+++ b/docs/tutorial_scg_backend.md
@@ -57,7 +57,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 5. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
     $ sdev    # SCG cluster does not allow building a container on login node
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.2.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.2.0
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.3.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.3.0
     $ exit
     ```
 
@@ -76,7 +76,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.2.0.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.0.simg",
             "singularity_bindpath" : "/scratch/users,/srv/gsfs0,/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/tutorial_sge.md
+++ b/docs/tutorial_sge.md
@@ -61,7 +61,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.2.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.2.0
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.3.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.3.0
     ```
 
 8. Run a pipeline for the test sample. If your parallel environment (PE) found from step 5) has a different name from `shm` then edit the following shell script to change the PE name.
@@ -83,7 +83,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.2.0.simg",
+            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.3.0.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR2,..."
         }
     }

--- a/docs/tutorial_sge_backend.md
+++ b/docs/tutorial_sge_backend.md
@@ -67,7 +67,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.2.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.3.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.1
     ```
 
 8. Run a pipeline for the test sample.

--- a/docs/tutorial_sherlock.md
+++ b/docs/tutorial_sherlock.md
@@ -68,7 +68,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.2.0.simg",
+            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.3.0.simg",
             "singularity_bindpath" : "/scratch,/lscratch,/oak/stanford,/home/groups/cherry/encode,/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/tutorial_sherlock_backend.md
+++ b/docs/tutorial_sherlock_backend.md
@@ -63,7 +63,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 6. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`. Stanford Sherlock does not allow building a container on login nodes. Wait until you get a command prompt after `sdev`.
     ```bash
     $ sdev    # sherlock cluster does not allow building a container on login node
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.2.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.2.0
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.3.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.3.0
     $ exit    # exit from an interactive node
     ```
 
@@ -81,7 +81,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.2.0.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.0.simg",
             "singularity_bindpath" : "/scratch,/oak/stanford,/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR1,..."
         }
     }

--- a/docs/tutorial_slurm.md
+++ b/docs/tutorial_slurm.md
@@ -56,7 +56,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.2.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.2.0
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.3.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.3.0
     ```
 
 8. Run a pipeline for the test sample. If your cluster requires to specify any of them then add one to the command line.
@@ -78,7 +78,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.2.0.simg",
+            "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.3.0.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR2,..."
         }
     }

--- a/docs/tutorial_slurm_backend.md
+++ b/docs/tutorial_slurm_backend.md
@@ -68,7 +68,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
 
 7. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```bash
-    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.2.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.2.0
+    $ mkdir -p ~/.singularity && cd ~/.singularity && SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull --name atac-seq-pipeline-v1.3.0.simg -F docker://quay.io/encode-dcc/atac-seq-pipeline:v1.3.0
     ```
 
 8. Run a pipeline for the test sample.
@@ -85,7 +85,7 @@ Our pipeline supports both [Conda](https://conda.io/docs/) and [Singularity](htt
     ```javascript
     {
         "default_runtime_attributes" : {
-            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.2.0.simg",
+            "singularity_container" : "~/.singularity/chip-seq-pipeline-v1.3.0.simg",
             "singularity_bindpath" : "/your/,YOUR_OWN_DATA_DIR1,YOUR_OWN_DATA_DIR2,..."
         }
     }

--- a/src/encode_ataqc.py
+++ b/src/encode_ataqc.py
@@ -200,11 +200,12 @@ def ataqc():
         flagstat_map = parse_flagstat_qc(args.flagstat_log)
         with open(args.flagstat_log,'r') as fp:
             flagstat = fp.read()
-        mapped_count = flagstat_map['mapped']
+        #mapped_count = flagstat_map['mapped']
     else:
         flagstat = None
-        mapped_count = None
-
+        #mapped_count = None
+    mapped_count = get_mapped_count(ALIGNED_BAM)
+        
     if ALIGNED_BAM and FINAL_BAM:
         # Final read statistics
         first_read_count, final_read_count, \

--- a/src/encode_ataqc.py
+++ b/src/encode_ataqc.py
@@ -205,7 +205,6 @@ def ataqc():
             flagstat = fp.read()
     else:
         flagstat = None
-    mapped_count = get_mapped_count(ALIGNED_BAM)
         
     if ALIGNED_BAM and FINAL_BAM:
         # Final read statistics

--- a/src/encode_ataqc.py
+++ b/src/encode_ataqc.py
@@ -200,10 +200,8 @@ def ataqc():
         flagstat_map = parse_flagstat_qc(args.flagstat_log)
         with open(args.flagstat_log,'r') as fp:
             flagstat = fp.read()
-        #mapped_count = flagstat_map['mapped']
     else:
         flagstat = None
-        #mapped_count = None
     mapped_count = get_mapped_count(ALIGNED_BAM)
         
     if ALIGNED_BAM and FINAL_BAM:

--- a/src/encode_ataqc.py
+++ b/src/encode_ataqc.py
@@ -153,10 +153,13 @@ def ataqc():
 
         # Filtering metrics: duplicates, map quality
         num_mapq, fract_mapq = get_fract_mapq(ALIGNED_BAM)
+
+        mapped_count = get_mapped_count(ALIGNED_BAM)
     else:
         picard_est_library_size = None
         preseq_data, preseq_log = (None, None)
         num_mapq, fract_mapq = (None, None)
+        mapped_count = None
 
     if PBC_LOG:
         encode_lib_metrics = get_encode_complexity_measures(PBC_LOG)

--- a/src/run_ataqc.py
+++ b/src/run_ataqc.py
@@ -1330,8 +1330,8 @@ into consideration as necessary.
   {{ inline_img(sample['enrichment_plots']['tss']) }}
   <pre>
 Open chromatin assays should show enrichment in open chromatin sites, such as
-TSS's. An average TSS enrichment is above 6-7. A strong TSS enrichment is
-above 10.
+TSS's. An average TSS enrichment in human (hg19) is above 6. A strong TSS enrichment is
+above 10. For other references please see https://www.encodeproject.org/atac-seq/
   </pre>
 {% endif %}
 

--- a/src/run_ataqc.py
+++ b/src/run_ataqc.py
@@ -518,7 +518,7 @@ def get_picard_dup_stats(picard_dup_file, paired_status):
                 dup_stats['READ_PAIR_DUPLICATES'] = line_elems[5]
                 dup_stats['READ_PAIRS_EXAMINED'] = line_elems[2]
                 if paired_status == 'Paired-ended':
-                    return float(line_elems[5]), float(line_elems[7])
+                    return 2*float(line_elems[5]), float(line_elems[7])
                 else:
                     return float(line_elems[4]), float(line_elems[7])
 
@@ -635,6 +635,21 @@ def get_samtools_flagstat(bam_file):
     return flagstat, mapped_reads
 
 
+def get_mapped_count(bam_file):
+    """run samtools view, removing unmapped (0x4) and nonprimary (0x100)
+    """
+    # Current bug in pysam.view module...
+    logging.info("getting mapped count...")
+
+    # There is a bug in pysam.view('-c'), so just use subprocess
+    num_mapped = int(subprocess.check_output(
+        ["samtools", "view",
+         "-F", "260", "-c",
+         bam_file]).strip())
+    
+    return num_mapped
+
+
 def get_fract_mapq(bam_file, q=30):
     '''
     Runs samtools view to get the fraction of reads of a certain
@@ -644,12 +659,14 @@ def get_fract_mapq(bam_file, q=30):
     logging.info('samtools mapq 30...')
 
     # There is a bug in pysam.view('-c'), so just use subprocess
-    num_qreads = int(subprocess.check_output(['samtools',
-                                              'view', '-c',
-                                              '-q', str(q), bam_file]).strip())
-    tot_reads = int(subprocess.check_output(['samtools',
-                                             'view', '-c',
-                                             bam_file]).strip())
+    num_qreads = int(subprocess.check_output(
+        ["samtools", "view",
+         "-F", "256", "-c",
+         '-q', str(q), bam_file]).strip())
+    tot_reads = int(subprocess.check_output(
+        ["samtools", "view",
+         "-F", "256", "-c",
+         bam_file]).strip())
     fract_good_mapq = float(num_qreads)/tot_reads
     return num_qreads, fract_good_mapq
 
@@ -660,12 +677,14 @@ def get_final_read_count(first_bam, last_bam):
     '''
     logging.info('final read counts...')
     # Bug in pysam.view
-    num_reads_last_bam = int(subprocess.check_output(['samtools',
-                                                      'view', '-c',
-                                                      last_bam]).strip())
-    num_reads_first_bam = int(subprocess.check_output(['samtools',
-                                                       'view', '-c',
-                                                       first_bam]).strip())
+    num_reads_last_bam = int(subprocess.check_output(
+        ["samtools", "view",
+         "-F", "256", "-c",
+         last_bam]).strip())
+    num_reads_first_bam = int(subprocess.check_output(
+        ["samtools", "view",
+         "-F", "256", "-c",
+         first_bam]).strip())
     fract_reads_left = float(num_reads_last_bam)/num_reads_first_bam
 
     return num_reads_first_bam, num_reads_last_bam, fract_reads_left
@@ -1139,6 +1158,11 @@ if your file is paired end, then you should divide these counts by two.
   <pre>
 {{ sample['samtools_flagstat'] }}
   </pre>
+<pre>
+Note that the flagstat command counts alignments, not reads. please 
+use the read counts table to get accurate counts of reads at each
+stage of the pipeline.
+</pre>
 {% endif %}
 
 {% if 'filtering_stats' in sample %}
@@ -1521,8 +1545,9 @@ def main():
                                                     MITO_CHR_NAME,
                                                     paired_status,
                                                     use_sambamba=USE_SAMBAMBA_MARKDUP)
-    [flagstat, mapped_count] = get_samtools_flagstat(ALIGNED_BAM)
-
+    flagstat, _ = get_samtools_flagstat(ALIGNED_BAM)
+    mapped_count = get_mapped_count(ALIGNED_BAM)
+    
     # Final read statistics
     first_read_count, final_read_count, \
         fract_reads_left = get_final_read_count(ALIGNED_BAM,

--- a/test/test_task/test.sh
+++ b/test/test_task/test.sh
@@ -12,7 +12,7 @@ INPUT=$2
 if [ $# -gt 2 ]; then
   DOCKER_IMAGE=$3
 else
-  DOCKER_IMAGE=quay.io/encode-dcc/atac-seq-pipeline:test-v1.2.0
+  DOCKER_IMAGE=quay.io/encode-dcc/atac-seq-pipeline:test-v1.3.0
 fi
 if [ $# -gt 3 ]; then
   NUM_TASK=$4

--- a/test/test_task/test_ataqc.json
+++ b/test/test_task/test_ataqc.json
@@ -26,9 +26,9 @@
     "test_ataqc.overlap_peak" : "atac-seq-pipeline-test-data/input/pe/ataqc/test_ataqc_full_chr_ppr.naive_overlap.filt.narrowPeak.gz",
     "test_ataqc.pval_bw" : "atac-seq-pipeline-test-data/input/pe/ataqc/ENCFF341MYG.subsampled.400.trim.merged.nodup.tn5.pval.signal.bigwig",
 
-    "test_ataqc.ref_qc_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/v1.1.7.2/ENCFF341MYG.subsampled.400.trim.merged_qc.txt",
+    "test_ataqc.ref_qc_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/v1.3.0/ENCFF341MYG.subsampled.400.trim.merged_qc.txt",
     "test_ataqc.ref_qc_align_only_1_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/align_only_1/ENCFF341MYG.subsampled.400.trim.merged.nodup_qc.txt",
     "test_ataqc.ref_qc_align_only_2_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/align_only_2/ENCFF341MYG.subsampled.400.trim.merged_qc.txt",
     "test_ataqc.ref_qc_peak_only_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/peak_only/test_ataqc_full_chr_rep1-pr.IDR0.05.filt_qc.txt",
-    "test_ataqc.ref_qc_tss_enrich_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/v1.1.7.2/tss_enrich/ENCFF341MYG.subsampled.400.trim.merged.nodup_qc.txt"
+    "test_ataqc.ref_qc_tss_enrich_txt" : "atac-seq-pipeline-test-data/ref_output/test_ataqc/v1.3.0/tss_enrich/ENCFF341MYG.subsampled.400.trim.merged.nodup_qc.txt"
 }

--- a/test/test_workflow/ENCSR356KRQ_subsampled.json
+++ b/test/test_workflow/ENCSR356KRQ_subsampled.json
@@ -1,5 +1,5 @@
 {
-    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.7.2/ENCSR356KRQ_subsampled/qc.json",
+    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.3.0/ENCSR356KRQ_subsampled/qc.json",
     "atac.pipeline_type" : "atac",
     "atac.genome_tsv" : "gs://encode-pipeline-genome-data/hg38_google.tsv",
     "atac.fastqs_rep1_R1" : [

--- a/test/test_workflow/ENCSR889WQX_subsampled.json
+++ b/test/test_workflow/ENCSR889WQX_subsampled.json
@@ -1,5 +1,5 @@
 {
-    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.1.6.a/ENCSR889WQX_subsampled/qc.json",
+    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.3.0/ENCSR889WQX_subsampled/qc.json",
     "atac.pipeline_type" : "atac",
     "atac.genome_tsv" : "gs://encode-pipeline-genome-data/mm10_google.tsv",
     "atac.fastqs_rep1_R1" : [

--- a/test/test_workflow/ref_output/v1.3.0/ENCSR356KRQ_subsampled/qc.json
+++ b/test/test_workflow/ref_output/v1.3.0/ENCSR356KRQ_subsampled/qc.json
@@ -1,0 +1,457 @@
+{
+    "general": {
+        "date": "2019-04-26 12:02:57", 
+        "pipeline_ver": "v1.3.0", 
+        "peak_caller": "macs2", 
+        "genome": "hg38_klab.tsv", 
+        "description": "ATAC-seq on primary keratinocytes in day 0.0 of differentiation", 
+        "title": "ENCSR356KRQ (1/400 subsampled)", 
+        "paired_end": [
+            true, 
+            true
+        ]
+    }, 
+    "flagstat_qc": {
+        "rep1": {
+            "total": 1286827, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 1281533, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 99.59, 
+            "paired": 691166, 
+            "paired_qc_failed": 0, 
+            "read1": 345583, 
+            "read1_qc_failed": 0, 
+            "read2": 345583, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 605666, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 87.63, 
+            "with_itself": 684846, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 1026, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.15, 
+            "diff_chroms": 553, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 1641618, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 1638620, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 99.82, 
+            "paired": 848854, 
+            "paired_qc_failed": 0, 
+            "read1": 424427, 
+            "read1_qc_failed": 0, 
+            "read2": 424427, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 748282, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 88.15, 
+            "with_itself": 844410, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 1446, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.17, 
+            "diff_chroms": 720, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "dup_qc": {
+        "rep1": {
+            "unpaired_reads": 0, 
+            "paired_reads": 220822, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 0, 
+            "paired_dupes": 682, 
+            "paired_opt_dupes": 3, 
+            "dupes_pct": 0.003088
+        }, 
+        "rep2": {
+            "unpaired_reads": 0, 
+            "paired_reads": 264763, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 0, 
+            "paired_dupes": 1312, 
+            "paired_opt_dupes": 4, 
+            "dupes_pct": 0.004955
+        }
+    }, 
+    "pbc_qc": {
+        "rep1": {
+            "total_read_pairs": 210134, 
+            "distinct_read_pairs": 209477, 
+            "one_read_pair": 209023, 
+            "two_read_pair": 357, 
+            "NRF": 0.996873, 
+            "PBC1": 0.997833, 
+            "PBC2": 585.498599
+        }, 
+        "rep2": {
+            "total_read_pairs": 249549, 
+            "distinct_read_pairs": 248592, 
+            "one_read_pair": 248018, 
+            "two_read_pair": 416, 
+            "NRF": 0.996165, 
+            "PBC1": 0.997691, 
+            "PBC2": 596.197115
+        }
+    }, 
+    "nodup_flagstat_qc": {
+        "rep1": {
+            "total": 440280, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 440280, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 440280, 
+            "paired_qc_failed": 0, 
+            "read1": 220140, 
+            "read1_qc_failed": 0, 
+            "read2": 220140, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 440280, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 100.0, 
+            "with_itself": 440280, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 526902, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 526902, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 526902, 
+            "paired_qc_failed": 0, 
+            "read1": 263451, 
+            "read1_qc_failed": 0, 
+            "read2": 263451, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 526902, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 100.0, 
+            "with_itself": 526902, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "overlap_reproducibility_qc": {
+        "Nt": 32588, 
+        "N1": 14546, 
+        "N2": 16009, 
+        "Np": 32823, 
+        "N_opt": 32823, 
+        "N_consv": 32588, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.0072112434, 
+        "self_consistency_ratio": 1.10057747834, 
+        "reproducibility": "pass"
+    }, 
+    "idr_reproducibility_qc": {
+        "Nt": 499, 
+        "N1": 132, 
+        "N2": 157, 
+        "Np": 639, 
+        "N_opt": 639, 
+        "N_consv": 499, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.28056112224, 
+        "self_consistency_ratio": 1.18939393939, 
+        "reproducibility": "pass"
+    }, 
+    "xcor_score": {
+        "rep1": {
+            "num_reads": 209895, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.00855237457383064, 
+            "phantom_peak": 70, 
+            "corr_phantom_peak": 0.009261564, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.00410843, 
+            "NSC": 2.081665, 
+            "RSC": 0.8623771
+        }, 
+        "rep2": {
+            "num_reads": 249245, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.00984122742143778, 
+            "phantom_peak": 65, 
+            "corr_phantom_peak": 0.01161518, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.005227118, 
+            "NSC": 1.882725, 
+            "RSC": 0.7223014
+        }
+    }, 
+    "frip_macs2_qc": {
+        "rep1": {
+            "FRiP": 0.989959265347
+        }, 
+        "rep2": {
+            "FRiP": 0.978581315573
+        }, 
+        "rep1-pr1": {
+            "FRiP": 0.996717421961
+        }, 
+        "rep2-pr1": {
+            "FRiP": 0.995931730098
+        }, 
+        "rep1-pr2": {
+            "FRiP": 0.996707862064
+        }, 
+        "rep2-pr2": {
+            "FRiP": 0.996609747878
+        }, 
+        "pooled": {
+            "FRiP": 0.684160604609
+        }, 
+        "ppr1": {
+            "FRiP": 0.98916457218
+        }, 
+        "ppr2": {
+            "FRiP": 0.989639280565
+        }
+    }, 
+    "overlap_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.212792394477
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.163567498035
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.159447531545
+        }, 
+        "ppr": {
+            "FRiP": 0.214356187655
+        }
+    }, 
+    "idr_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.0147896066559
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.00646751947402
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.00797006961022
+        }, 
+        "ppr": {
+            "FRiP": 0.0168412684584
+        }
+    }, 
+    "ataqc": {
+        "rep1": {
+            "Genome": "GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz", 
+            "Paired/Single-ended": "Paired-ended", 
+            "Read length": 76, 
+            "Read count from sequencer": 691166, 
+            "Read count successfully aligned": 685872, 
+            "Read count after filtering for mapping quality": 577552, 
+            "Read count after removing duplicate reads": 576870, 
+            "Read count after removing mitochondrial reads (final read count)": 440280, 
+            "Mapping quality > q30 (out of total)": [
+                577552, 
+                0.835619807687
+            ], 
+            "Duplicates (after filtering)": [
+                682, 
+                0.003088
+            ], 
+            "Mitochondrial reads (out of total)": [
+                48934, 
+                0.0381839562462
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                886, 
+                0.649560117302
+            ], 
+            "Final reads (after all filters)": [
+                440280, 
+                0.637010501095
+            ], 
+            "NRF": [
+                0.996873, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.997833, 
+                "OK"
+            ], 
+            "PBC2": [
+                585.498599, 
+                "OK"
+            ], 
+            "picard_est_library_size": 51268130, 
+            "Fraction of reads in NFR": [
+                0.521290815352, 
+                "OK"
+            ], 
+            "NFR / mono-nuc reads": [
+                1.68093590571, 
+                "out of range [2.5, inf]"
+            ], 
+            "Presence of NFR peak": "OK", 
+            "Presence of Mono-Nuc peak": "OK", 
+            "Presence of Di-Nuc peak": "OK", 
+            "Naive overlap peaks": [
+                32823, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                639, 
+                "out of range [10000, inf]"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 141.0, 
+            "Naive peak stats: 50 percentile (median)": 209.0, 
+            "Naive peak stats: 75 percentile": 293.0, 
+            "Naive peak stats: Max size": 1206.0, 
+            "Naive peak stats: Mean": 231.782225878, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 186.0, 
+            "IDR peak stats: 50 percentile (median)": 337.0, 
+            "IDR peak stats: 75 percentile": 451.5, 
+            "IDR peak stats: Max size": 819.0, 
+            "IDR peak stats: Mean": 333.9342723, 
+            "TSS_enrichment": 20.3977388654, 
+            "Fraction of reads in universal DHS regions": [
+                207705, 
+                0.494783105839
+            ], 
+            "Fraction of reads in blacklist regions": [
+                8, 
+                1.90571476214e-05
+            ], 
+            "Fraction of reads in promoter regions": [
+                69869, 
+                0.166437980895
+            ], 
+            "Fraction of reads in enhancer regions": [
+                170294, 
+                0.40566473713
+            ], 
+            "Fraction of reads in called peak regions": [
+                2715, 
+                0.00646751947402
+            ]
+        }, 
+        "rep2": {
+            "Genome": "GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz", 
+            "Paired/Single-ended": "Paired-ended", 
+            "Read length": 76, 
+            "Read count from sequencer": 848854, 
+            "Read count successfully aligned": 845856, 
+            "Read count after filtering for mapping quality": 693408, 
+            "Read count after removing duplicate reads": 692096, 
+            "Read count after removing mitochondrial reads (final read count)": 526902, 
+            "Mapping quality > q30 (out of total)": [
+                693408, 
+                0.81687545797
+            ], 
+            "Duplicates (after filtering)": [
+                1312, 
+                0.004955
+            ], 
+            "Mitochondrial reads (out of total)": [
+                69935, 
+                0.0426792056731
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                2016, 
+                0.768292682927
+            ], 
+            "Final reads (after all filters)": [
+                526902, 
+                0.620721584631
+            ], 
+            "NRF": [
+                0.996165, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.997691, 
+                "OK"
+            ], 
+            "PBC2": [
+                596.197115, 
+                "OK"
+            ], 
+            "picard_est_library_size": 40892504, 
+            "Fraction of reads in NFR": [
+                0.563787837345, 
+                "OK"
+            ], 
+            "NFR / mono-nuc reads": [
+                1.97030084172, 
+                "out of range [2.5, inf]"
+            ], 
+            "Presence of NFR peak": "OK", 
+            "Presence of Mono-Nuc peak": "OK", 
+            "Presence of Di-Nuc peak": "OK", 
+            "Naive overlap peaks": [
+                32823, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                639, 
+                "out of range [10000, inf]"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 141.0, 
+            "Naive peak stats: 50 percentile (median)": 209.0, 
+            "Naive peak stats: 75 percentile": 293.0, 
+            "Naive peak stats: Max size": 1206.0, 
+            "Naive peak stats: Mean": 231.782225878, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 186.0, 
+            "IDR peak stats: 50 percentile (median)": 337.0, 
+            "IDR peak stats: 75 percentile": 451.5, 
+            "IDR peak stats: Max size": 819.0, 
+            "IDR peak stats: Mean": 333.9342723, 
+            "TSS_enrichment": 17.8908961998, 
+            "Fraction of reads in universal DHS regions": [
+                229492, 
+                0.460374330478
+            ], 
+            "Fraction of reads in blacklist regions": [
+                8, 
+                1.60484663684e-05
+            ], 
+            "Fraction of reads in promoter regions": [
+                74604, 
+                0.149659973119
+            ], 
+            "Fraction of reads in enhancer regions": [
+                194866, 
+                0.390912555919
+            ], 
+            "Fraction of reads in called peak regions": [
+                3973, 
+                0.00797006961022
+            ]
+        }
+    }
+}

--- a/test/test_workflow/ref_output/v1.3.0/ENCSR889WQX_subsampled/qc.json
+++ b/test/test_workflow/ref_output/v1.3.0/ENCSR889WQX_subsampled/qc.json
@@ -1,0 +1,434 @@
+{
+    "general": {
+        "date": "2019-04-26 12:14:45", 
+        "pipeline_ver": "v1.3.0", 
+        "peak_caller": "macs2", 
+        "genome": "mm10_klab.tsv", 
+        "description": "ATAC-seq on Mus musculus C57BL/6 frontal cortex adult", 
+        "title": "ENCSR889WQX", 
+        "paired_end": []
+    }, 
+    "flagstat_qc": {
+        "rep1": {
+            "total": 356699, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 326957, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 91.66, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 301254, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 298157, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 98.97, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "dup_qc": {
+        "rep1": {
+            "unpaired_reads": 139121, 
+            "paired_reads": 0, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 36851, 
+            "paired_dupes": 0, 
+            "paired_opt_dupes": 0, 
+            "dupes_pct": 0.264885
+        }, 
+        "rep2": {
+            "unpaired_reads": 134177, 
+            "paired_reads": 0, 
+            "unmapped_reads": 0, 
+            "unpaired_dupes": 9251, 
+            "paired_dupes": 0, 
+            "paired_opt_dupes": 0, 
+            "dupes_pct": 0.068946
+        }
+    }, 
+    "pbc_qc": {
+        "rep1": {
+            "total_read_pairs": 95203, 
+            "distinct_read_pairs": 92035, 
+            "one_read_pair": 90553, 
+            "two_read_pair": 815, 
+            "NRF": 0.966724, 
+            "PBC1": 0.983897, 
+            "PBC2": 111.107975
+        }, 
+        "rep2": {
+            "total_read_pairs": 118878, 
+            "distinct_read_pairs": 117806, 
+            "one_read_pair": 117144, 
+            "two_read_pair": 440, 
+            "NRF": 0.990982, 
+            "PBC1": 0.994381, 
+            "PBC2": 266.236364
+        }
+    }, 
+    "nodup_flagstat_qc": {
+        "rep1": {
+            "total": 102270, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 102270, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }, 
+        "rep2": {
+            "total": 124926, 
+            "total_qc_failed": 0, 
+            "duplicates": 0, 
+            "duplicates_qc_failed": 0, 
+            "mapped": 124926, 
+            "mapped_qc_failed": 0, 
+            "mapped_pct": 100.0, 
+            "paired": 0, 
+            "paired_qc_failed": 0, 
+            "read1": 0, 
+            "read1_qc_failed": 0, 
+            "read2": 0, 
+            "read2_qc_failed": 0, 
+            "paired_properly": 0, 
+            "paired_properly_qc_failed": 0, 
+            "paired_properly_pct": 0.0, 
+            "with_itself": 0, 
+            "with_itself_qc_failed": 0, 
+            "singletons": 0, 
+            "singletons_qc_failed": 0, 
+            "singletons_pct": 0.0, 
+            "diff_chroms": 0, 
+            "diff_chroms_qc_failed": 0
+        }
+    }, 
+    "overlap_reproducibility_qc": {
+        "Nt": 116400, 
+        "N1": 45966, 
+        "N2": 64625, 
+        "Np": 113320, 
+        "N_opt": 116400, 
+        "N_consv": 116400, 
+        "opt_set": "rep1-rep2", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.0271796682, 
+        "self_consistency_ratio": 1.40593047035, 
+        "reproducibility": "pass"
+    }, 
+    "idr_reproducibility_qc": {
+        "Nt": 75, 
+        "N1": 39, 
+        "N2": 29, 
+        "Np": 101, 
+        "N_opt": 101, 
+        "N_consv": 75, 
+        "opt_set": "ppr", 
+        "consv_set": "rep1-rep2", 
+        "rescue_ratio": 1.34666666667, 
+        "self_consistency_ratio": 1.34482758621, 
+        "reproducibility": "pass"
+    }, 
+    "xcor_score": {
+        "rep1": {
+            "num_reads": 89776, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.0493311358183571, 
+            "phantom_peak": 40, 
+            "corr_phantom_peak": 0.04961571, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.02846737, 
+            "NSC": 1.732901, 
+            "RSC": 0.9865438
+        }, 
+        "rep2": {
+            "num_reads": 117515, 
+            "est_frag_len": 0, 
+            "corr_est_frag_len": 0.0187798702155508, 
+            "phantom_peak": 40, 
+            "corr_phantom_peak": 0.01772723, 
+            "argmin_corr": 1500, 
+            "min_corr": 0.01020629, 
+            "NSC": 1.840029, 
+            "RSC": 1.139961
+        }
+    }, 
+    "frip_macs2_qc": {
+        "rep1": {
+            "FRiP": 0.97891418642
+        }, 
+        "rep2": {
+            "FRiP": 0.993124282007
+        }, 
+        "rep1-pr1": {
+            "FRiP": 0.967942434504
+        }, 
+        "rep2-pr1": {
+            "FRiP": 0.989771605569
+        }, 
+        "rep1-pr2": {
+            "FRiP": 0.972932632329
+        }, 
+        "rep2-pr2": {
+            "FRiP": 0.988341814592
+        }, 
+        "pooled": {
+            "FRiP": 0.986714329132
+        }, 
+        "ppr1": {
+            "FRiP": 0.985498716786
+        }, 
+        "ppr2": {
+            "FRiP": 0.984533744995
+        }
+    }, 
+    "overlap_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.784587849931
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.910399215826
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.852223120453
+        }, 
+        "ppr": {
+            "FRiP": 0.768798452417
+        }
+    }, 
+    "idr_frip_qc": {
+        "rep1-rep2": {
+            "FRiP": 0.0162573387171
+        }, 
+        "rep1-pr": {
+            "FRiP": 0.0229459989307
+        }, 
+        "rep2-pr": {
+            "FRiP": 0.00702038037697
+        }, 
+        "ppr": {
+            "FRiP": 0.0173041762546
+        }
+    }, 
+    "ataqc": {
+        "rep1": {
+            "Genome": "mm10_no_alt_analysis_set_ENCODE.fasta.gz", 
+            "Paired/Single-ended": "Single-ended", 
+            "Read length": 100, 
+            "Read count from sequencer": 200680, 
+            "Read count successfully aligned": 170938, 
+            "Read count after filtering for mapping quality": 135105, 
+            "Read count after removing duplicate reads": 98254, 
+            "Read count after removing mitochondrial reads (final read count)": 102270, 
+            "bowtie_stats": 200680, 
+            "Mapping quality > q30 (out of total)": [
+                135105, 
+                0.673235997608
+            ], 
+            "Duplicates (after filtering)": [
+                36851, 
+                0.264885
+            ], 
+            "Mitochondrial reads (out of total)": [
+                58673, 
+                0.179451732185
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                31424, 
+                0.852731269165
+            ], 
+            "Final reads (after all filters)": [
+                102270, 
+                0.509617301176
+            ], 
+            "NRF": [
+                0.966724, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.983897, 
+                "OK"
+            ], 
+            "PBC2": [
+                111.107975, 
+                "OK"
+            ], 
+            "picard_est_library_size": 0, 
+            "Naive overlap peaks": [
+                116400, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                101, 
+                "out of range [10000, inf]"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 73.0, 
+            "Naive peak stats: 50 percentile (median)": 73.0, 
+            "Naive peak stats: 75 percentile": 3371.25, 
+            "Naive peak stats: Max size": 89214999.0, 
+            "Naive peak stats: Mean": 16528.6690636, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 149.0, 
+            "IDR peak stats: 50 percentile (median)": 249.0, 
+            "IDR peak stats: 75 percentile": 362.0, 
+            "IDR peak stats: Max size": 37679.0, 
+            "IDR peak stats: Mean": 837.693069307, 
+            "TSS_enrichment": 29.0727191985, 
+            "Fraction of reads in universal DHS regions": [
+                51764, 
+                0.576590625557
+            ], 
+            "Fraction of reads in blacklist regions": [
+                240, 
+                0.00267332026377
+            ], 
+            "Fraction of reads in promoter regions": [
+                12150, 
+                0.135336838353
+            ], 
+            "Fraction of reads in enhancer regions": [
+                39516, 
+                0.440162181429
+            ], 
+            "Fraction of reads in called peak regions": [
+                2060, 
+                0.0229459989307
+            ]
+        }, 
+        "rep2": {
+            "Genome": "mm10_no_alt_analysis_set_ENCODE.fasta.gz", 
+            "Paired/Single-ended": "Single-ended", 
+            "Read length": 50, 
+            "Read count from sequencer": 169465, 
+            "Read count successfully aligned": 166368, 
+            "Read count after filtering for mapping quality": 144322, 
+            "Read count after removing duplicate reads": 135071, 
+            "Read count after removing mitochondrial reads (final read count)": 124926, 
+            "bowtie_stats": 169465, 
+            "Mapping quality > q30 (out of total)": [
+                144322, 
+                0.851633080577
+            ], 
+            "Duplicates (after filtering)": [
+                9251, 
+                0.068946
+            ], 
+            "Mitochondrial reads (out of total)": [
+                20535, 
+                0.0688731104754
+            ], 
+            "Duplicates that are mitochondrial (out of all dups)": [
+                7888, 
+                0.852664576803
+            ], 
+            "Final reads (after all filters)": [
+                124926, 
+                0.737178768477
+            ], 
+            "NRF": [
+                0.990982, 
+                "OK"
+            ], 
+            "PBC1": [
+                0.994381, 
+                "OK"
+            ], 
+            "PBC2": [
+                266.236364, 
+                "OK"
+            ], 
+            "picard_est_library_size": 0, 
+            "Naive overlap peaks": [
+                116400, 
+                "OK"
+            ], 
+            "IDR peaks": [
+                101, 
+                "out of range [10000, inf]"
+            ], 
+            "Naive peak stats: Min size": 73.0, 
+            "Naive peak stats: 25 percentile": 73.0, 
+            "Naive peak stats: 50 percentile (median)": 73.0, 
+            "Naive peak stats: 75 percentile": 3371.25, 
+            "Naive peak stats: Max size": 89214999.0, 
+            "Naive peak stats: Mean": 16528.6690636, 
+            "IDR peak stats: Min size": 73.0, 
+            "IDR peak stats: 25 percentile": 149.0, 
+            "IDR peak stats: 50 percentile (median)": 249.0, 
+            "IDR peak stats: 75 percentile": 362.0, 
+            "IDR peak stats: Max size": 37679.0, 
+            "IDR peak stats: Mean": 837.693069307, 
+            "TSS_enrichment": 17.9595743429, 
+            "Fraction of reads in universal DHS regions": [
+                71565, 
+                0.608986086883
+            ], 
+            "Fraction of reads in blacklist regions": [
+                154, 
+                0.0013104710037
+            ], 
+            "Fraction of reads in promoter regions": [
+                18766, 
+                0.159690252308
+            ], 
+            "Fraction of reads in enhancer regions": [
+                52846, 
+                0.449695783517
+            ], 
+            "Fraction of reads in called peak regions": [
+                825, 
+                0.00702038037697
+            ]
+        }
+    }
+}

--- a/test/test_workflow/test_atac.sh
+++ b/test/test_workflow/test_atac.sh
@@ -8,7 +8,7 @@ fi
 if [ $# -gt 2 ]; then
   DOCKER_IMAGE=$3
 else
-  DOCKER_IMAGE=quay.io/encode-dcc/atac-seq-pipeline:test-v1.2.0
+  DOCKER_IMAGE=quay.io/encode-dcc/atac-seq-pipeline:test-v1.3.0
 fi
 INPUT=$1
 GCLOUD_SERVICE_ACCOUNT_SECRET_JSON_FILE=$2

--- a/workflow_opts/docker.json
+++ b/workflow_opts/docker.json
@@ -1,6 +1,6 @@
 {
     "default_runtime_attributes" : {
-        "docker" : "quay.io/encode-dcc/atac-seq-pipeline:v1.2.0",
+        "docker" : "quay.io/encode-dcc/atac-seq-pipeline:v1.3.0",
         "zones": "us-west1-a us-west1-b us-west1-c us-central1-c us-central1-b",
         "failOnStderr" : false,
         "continueOnReturnCode" : 0,

--- a/workflow_opts/docker_test.json
+++ b/workflow_opts/docker_test.json
@@ -1,6 +1,6 @@
 {
     "default_runtime_attributes" : {
-        "docker" : "quay.io/encode-dcc/atac-seq-pipeline:test-v1.2.0",
+        "docker" : "quay.io/encode-dcc/atac-seq-pipeline:test-v1.3.0",
         "zones": "us-west1-a us-west1-b us-west1-c us-central1-c us-central1-b",
         "failOnStderr" : false,
         "continueOnReturnCode" : 0,

--- a/workflow_opts/scg.json
+++ b/workflow_opts/scg.json
@@ -1,7 +1,7 @@
 {
     "default_runtime_attributes" : {
         "slurm_account" : "YOUR_SLURM_ACCOUNT",
-        "singularity_container" : "/reference/ENCODE/pipeline_singularity_images/atac-seq-pipeline-v1.2.0.simg",
+        "singularity_container" : "/reference/ENCODE/pipeline_singularity_images/atac-seq-pipeline-v1.3.0.simg",
         "singularity_bindpath" : "/reference/ENCODE,/scratch,/srv/gsfs0"
     }
 }

--- a/workflow_opts/sge.json
+++ b/workflow_opts/sge.json
@@ -1,6 +1,6 @@
 {
     "default_runtime_attributes" : {
         "sge_pe" : "shm",
-        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.2.0.simg"
+        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.3.0.simg"
     }
 }

--- a/workflow_opts/sherlock.json
+++ b/workflow_opts/sherlock.json
@@ -1,7 +1,7 @@
 {
     "default_runtime_attributes" : {
         "slurm_partition" : "normal",
-        "singularity_container" : "/home/groups/cherry/encode/pipeline_singularity_images/atac-seq-pipeline-v1.2.0.simg",
+        "singularity_container" : "/home/groups/cherry/encode/pipeline_singularity_images/atac-seq-pipeline-v1.3.0.simg",
         "singularity_bindpath" : "/scratch,/lscratch,/oak/stanford,/home/groups/cherry/encode"
     }
 }

--- a/workflow_opts/singularity.json
+++ b/workflow_opts/singularity.json
@@ -1,5 +1,5 @@
 {
     "default_runtime_attributes" : {
-        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.2.0.simg"
+        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.3.0.simg"
     }
 }

--- a/workflow_opts/slurm.json
+++ b/workflow_opts/slurm.json
@@ -2,6 +2,6 @@
     "default_runtime_attributes" : {
         "slurm_partition" : "YOUR_SLURM_PARTITION",
         "slurm_account" : "YOUR_SLURM_ACCOUNT",
-        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.2.0.simg"
+        "singularity_container" : "~/.singularity/atac-seq-pipeline-v1.3.0.simg"
     }
 }


### PR DESCRIPTION
makes sure to filter out nonprimary alignments so that `samtools -c` will properly count reads vs alignments. resolves #80 