### PR TITLE
add MITO_CHR_NAME to README

### DIFF
--- a/docs/build_genome_database.md
+++ b/docs/build_genome_database.md
@@ -49,6 +49,7 @@
     elif [[ $GENOME == "YOUR_OWN_GENOME" ]]; then
       REF_FA="URL_FOR_YOUR_FASTA_OR_2BIT"
       BLACKLIST= # leave it empty if you don't have it
+      MITO_CHR_NAME= # name for mitochondrial chromosome in reference genome, e.g. chrM, MT
 
     ...
     ```


### PR DESCRIPTION
I was trying to use an old custom genome database and got the following error: "message": "Failed to evaluate input 'mito_chr_name' (reason 1 of 1): Failed to lookup input value for required input mito_chr_name"

So I think it is required to rebuild genome databases and include this parameter in `build_genome_database.sh`