### PR TITLE
Pip 807 update for v1.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,22 @@ jobs:
             ./test_atac.sh ENCSR356KRQ_subsampled.json tmp_key.json ${TAG}
             python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'outputs'][u'atac.qc_json_ref_match']))" < ENCSR356KRQ_subsampled.metadata.json
 
+  test_workflow_pe_start_from_bam:
+    <<: *machine_defaults
+    steps:
+      - checkout
+      - run: *make_tag
+      - run:
+          no_output_timeout: 300m
+          command: |
+            source ${BASH_ENV}
+            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+            cd dev/test/test_workflow/
+            echo ${GCLOUD_SERVICE_ACCOUNT_SECRET_JSON} > tmp_key.json
+            ./test_atac.sh ENCSR356KRQ_subsampled_start_from_bam.json tmp_key.json ${TAG}
+            python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'outputs'][u'atac.qc_json_ref_match']))" < ENCSR356KRQ_subsampled_start_from_bam.metadata.json
+
+
 # Define workflow here
 workflows:
   version: 2
@@ -143,5 +159,8 @@ workflows:
           requires:
             - build
       - test_workflow_pe:
+          requires:
+            - build
+      - test_workflow_pe_start_from_bam:
           requires:
             - build

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The ATAC-seq pipeline protocol specification is [here](https://docs.google.com/d
 ## Installation
 
 1) Git clone this pipeline.
-	> **IMPORTANT*: use `~/atac-seq-pipeline/atac.wdl` as `[WDL]` in Caper's documentation.
+	> **IMPORTANT**: use `~/atac-seq-pipeline/atac.wdl` as `[WDL]` in Caper's documentation.
 
 	```bash
 	$ cd

--- a/README.md
+++ b/README.md
@@ -66,3 +66,16 @@ Install [Croo](https://github.com/ENCODE-DCC/croo#installation). **You can skip 
 $ pip install croo
 $ croo [METADATA_JSON_FILE]
 ```
+
+## How to make a spreadsheet of QC metrics
+
+Install [qc2tsv](https://github.com/ENCODE-DCC/qc2tsv#installation). Make sure that you have python3(> 3.4.1) installed on your system. 
+
+Once you have [organized output with Croo](#how-to-organize-outputs), you will be able to find pipeline's final output file `qc/qc.json` which has all QC metrics in it. Simply feed `qc2tsv` with multiple `qc.json` files. It can take various URIs like local path, `gs://` and `s3://`.
+
+```bash
+$ pip install qc2tsv
+$ qc2tsv /sample1/qc.json gs://sample2/qc.json s3://sample3/qc.json ... > spreadsheet.tsv
+```
+
+QC metrics for each experiment (`qc.json`) will be split into multiple rows (1 for overall experiment + 1 for each bio replicate) in a spreadsheet.

--- a/atac.wdl
+++ b/atac.wdl
@@ -1,13 +1,13 @@
 # ENCODE ATAC-Seq/DNase-Seq pipeline
 # Author: Jin Lee (leepc12@gmail.com)
 
-#CAPER docker quay.io/encode-dcc/atac-seq-pipeline:v1.5.2
-#CAPER singularity docker://quay.io/encode-dcc/atac-seq-pipeline:v1.5.2
+#CAPER docker quay.io/encode-dcc/atac-seq-pipeline:dev-v1.5.3
+#CAPER singularity docker://quay.io/encode-dcc/atac-seq-pipeline:dev-v1.5.3
 #CROO out_def https://storage.googleapis.com/encode-pipeline-output-definition/atac.croo.json
 
 workflow atac {
 	# pipeline version
-	String pipeline_ver = 'v1.5.2'
+	String pipeline_ver = 'dev-v1.5.3'
 
 	# general sample information
 	String title = 'Untitled'

--- a/atac.wdl
+++ b/atac.wdl
@@ -633,12 +633,11 @@ workflow atac {
 		}
 		# tasks factored out from ATAqC
 		Boolean has_input_of_tss_enrich = defined(nodup_bam_) && defined(tss_) && (
-			defined(align.read_len_log) || i<length(read_len) && defined(read_len[i]) )
+			defined(align.read_len) || i<length(read_len) && defined(read_len[i]) )
 		if ( enable_tss_enrich && has_input_of_tss_enrich ) {
-			Int? read_len_ = if i<length(read_len) && defined(read_len[i]) then read_len[i]
-				else read_int(align.read_len_log)
 			call tss_enrich { input :
-				read_len = read_len_,
+				read_len = if i<length(read_len) && defined(read_len[i]) then read_len[i]
+					else align.read_len,
 				nodup_bam = nodup_bam_,
 				tss = tss_,
 				chrsz = chrsz_,
@@ -1141,6 +1140,7 @@ task align {
 		File samstat_qc = glob('*.samstats.qc')[0]
 		File non_mito_samstat_qc = glob('non_mito/*.samstats.qc')[0]
 		File read_len_log = glob('*.read_length.txt')[0]
+		Int read_len = read_int(read_len_log)
 	}
 	runtime {
 		cpu : cpu

--- a/dev/test/test_workflow/ENCSR356KRQ_subsampled.json
+++ b/dev/test/test_workflow/ENCSR356KRQ_subsampled.json
@@ -29,7 +29,6 @@
     "atac.paired_end" : true,
     "atac.auto_detect_adapter" : true,
     "atac.enable_xcor" : true,
-    "atac.enable_tss_enrich" : false,
     "atac.title" : "ENCSR356KRQ (subsampled 1/400 reads)",
     "atac.description" : "ATAC-seq on primary keratinocytes in day 0.0 of differentiation"
 }

--- a/dev/test/test_workflow/ENCSR356KRQ_subsampled_start_from_bam.json
+++ b/dev/test/test_workflow/ENCSR356KRQ_subsampled_start_from_bam.json
@@ -1,0 +1,15 @@
+{
+    "atac.qc_report.qc_json_ref" : "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ref_output/v1.5.0/ENCSR356KRQ_subsampled_start_from_bam/qc.json",
+    "atac.pipeline_type" : "atac",
+    "atac.genome_tsv" : "gs://encode-pipeline-genome-data/genome_tsv/v1/hg38_gcp.tsv",
+    "atac.read_len" : [76, 76],
+    "atac.nodup_bams" : [
+        "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/bam_subsampled/rep1/ENCFF341MYG.subsampled.400.trim.merged.nodup.no_chrM_MT.bam",
+        "gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/bam_subsampled/rep2/ENCFF641SFZ.subsampled.400.trim.merged.nodup.no_chrM_MT.bam"
+    ],
+    "atac.paired_end" : true,
+    "atac.auto_detect_adapter" : true,
+    "atac.enable_xcor" : true,
+    "atac.title" : "ENCSR356KRQ (subsampled 1/400 reads, starting from BAM)",
+    "atac.description" : "ATAC-seq on primary keratinocytes in day 0.0 of differentiation"
+}

--- a/dev/test/test_workflow/ref_output/v1.5.0/ENCSR356KRQ_subsampled/qc.json
+++ b/dev/test/test_workflow/ref_output/v1.5.0/ENCSR356KRQ_subsampled/qc.json
@@ -1,16 +1,20 @@
 {
     "general": {
-        "date": "2019-10-10 06:20:41",
+        "date": "2019-11-07 02:13:22",
         "title": "ENCSR356KRQ (subsampled 1/400 reads)",
         "description": "ATAC-seq on primary keratinocytes in day 0.0 of differentiation",
-        "pipeline_ver": "dev-v1.5.0",
+        "pipeline_ver": "dev-v1.5.3",
         "pipeline_type": "atac",
         "genome": "hg38",
-        "paired_end": [
-            true,
-            true
-        ],
         "aligner": "bowtie2",
+        "seq_endedness": {
+            "rep1": {
+                "paired_end": true
+            },
+            "rep2": {
+                "paired_end": true
+            }
+        },
         "peak_caller": "macs2"
     },
     "align": {
@@ -270,14 +274,6 @@
         }
     },
     "align_enrich": {
-        "tss_enrich": {
-            "rep1": {
-                "tss_enrich": 19.06062750181121
-            },
-            "rep2": {
-                "tss_enrich": 16.757705401589984
-            }
-        },
         "xcor_score": {
             "rep1": {
                 "subsampled_reads": 228557,
@@ -300,6 +296,14 @@
                 "min_corr": 0.006548108,
                 "NSC": 1.918698,
                 "RSC": 0.973006
+            }
+        },
+        "tss_enrich": {
+            "rep1": {
+                "tss_enrich": 19.06062750181121
+            },
+            "rep2": {
+                "tss_enrich": 16.757705401589984
             }
         },
         "jsd": {

--- a/dev/test/test_workflow/ref_output/v1.5.0/ENCSR356KRQ_subsampled/qc.json
+++ b/dev/test/test_workflow/ref_output/v1.5.0/ENCSR356KRQ_subsampled/qc.json
@@ -270,6 +270,14 @@
         }
     },
     "align_enrich": {
+        "tss_enrich": {
+            "rep1": {
+                "tss_enrich": 19.06062750181121
+            },
+            "rep2": {
+                "tss_enrich": 16.757705401589984
+            }
+        },
         "xcor_score": {
             "rep1": {
                 "subsampled_reads": 228557,

--- a/dev/test/test_workflow/ref_output/v1.5.0/ENCSR356KRQ_subsampled_start_from_bam/qc.json
+++ b/dev/test/test_workflow/ref_output/v1.5.0/ENCSR356KRQ_subsampled_start_from_bam/qc.json
@@ -1,0 +1,225 @@
+{
+    "general": {
+        "date": "2019-11-06 14:31:41",
+        "title": "ENCSR356KRQ (subsampled 1/400, staring from NODUP_BAMs with specified read_len)",
+        "description": "ATAC-seq on primary keratinocytes in day 0.0 of differentiation",
+        "pipeline_ver": "v1.5.2",
+        "pipeline_type": "atac",
+        "genome": "hg38",
+        "aligner": "bowtie2",
+        "read_end": {
+            "rep1": {
+                "paired_end": true
+            },
+            "rep2": {
+                "paired_end": true
+            }
+        },
+        "peak_caller": "macs2"
+    },
+    "align": {
+        "frag_len_stat": {
+            "rep1": {
+                "frac_reads_in_nfr": 0.5025463237588045,
+                "frac_reads_in_nfr_qc_pass": true,
+                "frac_reads_in_nfr_qc_reason": "OK",
+                "nfr_over_mono_nuc_reads": 1.5317476261266691,
+                "nfr_over_mono_nuc_reads_qc_pass": false,
+                "nfr_over_mono_nuc_reads_qc_reason": "out of range [2.5, inf]",
+                "nfr_peak_exists": true,
+                "mono_nuc_peak_exists": true,
+                "di_nuc_peak_exists": true
+            },
+            "rep2": {
+                "frac_reads_in_nfr": 0.5463799114259104,
+                "frac_reads_in_nfr_qc_pass": true,
+                "frac_reads_in_nfr_qc_reason": "OK",
+                "nfr_over_mono_nuc_reads": 1.805493716774327,
+                "nfr_over_mono_nuc_reads_qc_pass": false,
+                "nfr_over_mono_nuc_reads_qc_reason": "out of range [2.5, inf]",
+                "nfr_peak_exists": true,
+                "mono_nuc_peak_exists": true,
+                "di_nuc_peak_exists": true
+            }
+        }
+    },
+    "replication": {
+        "reproducibility": {
+            "overlap": {
+                "Nt": 30208,
+                "N1": 14753,
+                "N2": 15865,
+                "Np": 32270,
+                "N_opt": 32270,
+                "N_consv": 30208,
+                "opt_set": "pooled-pr1_vs_pooled-pr2",
+                "consv_set": "rep1_vs_rep2",
+                "rescue_ratio": 1.068260063559322,
+                "self_consistency_ratio": 1.0753745001016743,
+                "reproducibility": "pass"
+            },
+            "idr": {
+                "Nt": 261,
+                "N1": 26,
+                "N2": 35,
+                "Np": 301,
+                "N_opt": 301,
+                "N_consv": 261,
+                "opt_set": "pooled-pr1_vs_pooled-pr2",
+                "consv_set": "rep1_vs_rep2",
+                "rescue_ratio": 1.1532567049808429,
+                "self_consistency_ratio": 1.3461538461538463,
+                "reproducibility": "pass"
+            }
+        },
+        "num_peaks": {
+            "rep1": {
+                "num_peaks": 297936
+            },
+            "rep2": {
+                "num_peaks": 299650
+            }
+        }
+    },
+    "peak_stat": {
+        "peak_region_size": {
+            "rep1": {
+                "min_size": 73.0,
+                "25_pct": 73.0,
+                "50_pct": 73.0,
+                "75_pct": 116.0,
+                "max_size": 860.0,
+                "mean": 100.73481888727781
+            },
+            "rep2": {
+                "min_size": 73.0,
+                "25_pct": 73.0,
+                "50_pct": 73.0,
+                "75_pct": 129.0,
+                "max_size": 1108.0,
+                "mean": 106.7660270315368
+            },
+            "idr_opt": {
+                "min_size": 73.0,
+                "25_pct": 273.0,
+                "50_pct": 359.0,
+                "75_pct": 426.0,
+                "max_size": 759.0,
+                "mean": 359.40199335548175
+            },
+            "overlap_opt": {
+                "min_size": 73.0,
+                "25_pct": 140.0,
+                "50_pct": 204.0,
+                "75_pct": 283.0,
+                "max_size": 1208.0,
+                "mean": 225.2372482181593
+            }
+        }
+    },
+    "align_enrich": {
+        "tss_enrich": {
+            "rep1": {
+                "tss_enrich": 19.06062750181121
+            },
+            "rep2": {
+                "tss_enrich": 16.757705401589984
+            }
+        },
+        "jsd": {
+            "rep1": {
+                "auc": 0.014255843988670825,
+                "syn_auc": 0.436685561986168,
+                "x_intercept": 0.9581259022004694,
+                "syn_x_intercept": 0.03741526373241471,
+                "elbow_pt": 0.9586297349280039,
+                "syn_elbow_pt": 0.59968520973226,
+                "syn_jsd": 0.10013462212316575
+            },
+            "rep2": {
+                "auc": 0.01687618984821658,
+                "syn_auc": 0.4413355590403154,
+                "x_intercept": 0.9509082984449163,
+                "syn_x_intercept": 0.018746630087640406,
+                "elbow_pt": 0.9515280926732325,
+                "syn_elbow_pt": 0.46029700985413047,
+                "syn_jsd": 0.09569441467036811
+            }
+        }
+    },
+    "peak_enrich": {
+        "frac_reads_in_peaks": {
+            "macs2": {
+                "rep1": {
+                    "frip": 0.9893866736736079
+                },
+                "rep2": {
+                    "frip": 0.8944475833376136
+                },
+                "rep1-pr1": {
+                    "frip": 0.9966104070139175
+                },
+                "rep2-pr1": {
+                    "frip": 0.996180741545167
+                },
+                "rep1-pr2": {
+                    "frip": 0.9962381319412815
+                },
+                "rep2-pr2": {
+                    "frip": 0.9958468774535342
+                },
+                "pooled": {
+                    "frip": 0.6275605846148318
+                },
+                "pooled-pr1": {
+                    "frip": 0.9538202318970198
+                },
+                "pooled-pr2": {
+                    "frip": 0.9613703060430018
+                }
+            },
+            "overlap": {
+                "rep1_vs_rep2": {
+                    "frip": 0.18011183623438096
+                },
+                "rep1-pr1_vs_rep1-pr2": {
+                    "frip": 0.14732312947513632
+                },
+                "rep2-pr1_vs_rep2-pr2": {
+                    "frip": 0.1404063602943874
+                },
+                "pooled-pr1_vs_pooled-pr2": {
+                    "frip": 0.18667986927817518
+                }
+            },
+            "idr": {
+                "rep1_vs_rep2": {
+                    "frip": 0.008217028573938285
+                },
+                "rep1-pr1_vs_rep1-pr2": {
+                    "frip": 0.0029779500317502023
+                },
+                "rep2-pr1_vs_rep2-pr2": {
+                    "frip": 0.0042833662305643404
+                },
+                "pooled-pr1_vs_pooled-pr2": {
+                    "frip": 0.00857537566553739
+                }
+            }
+        },
+        "frac_reads_in_annot": {
+            "rep1": {
+                "fri_dhs": 0.46616961177166133,
+                "fri_blacklist": 0.0005758829840811053,
+                "fri_prom": 0.15275788828308043,
+                "fri_enh": 0.39283540257067157
+            },
+            "rep2": {
+                "fri_dhs": 0.43002061885928544,
+                "fri_blacklist": 0.000680569109866968,
+                "fri_prom": 0.13694297894821805,
+                "fri_enh": 0.3754631905666884
+            }
+        }
+    }
+}

--- a/example_input_json/klab/ENCSR356KRQ_subsampled_start_from_bam_klab.json
+++ b/example_input_json/klab/ENCSR356KRQ_subsampled_start_from_bam_klab.json
@@ -1,0 +1,14 @@
+{
+    "atac.pipeline_type" : "atac",
+    "atac.genome_tsv" : "/mnt/data/pipeline_genome_data/genome_tsv/v1/hg38_klab.tsv",
+    "atac.nodup_bams" : [
+         "/mnt/data/pipeline_test_samples/encode-atac-seq-pipeline/ENCSR356KRQ/bam_subsampled/rep1/ENCFF341MYG.subsampled.400.trim.merged.nodup.no_chrM_MT.bam",
+         "/mnt/data/pipeline_test_samples/encode-atac-seq-pipeline/ENCSR356KRQ/bam_subsampled/rep2/ENCFF641SFZ.subsampled.400.trim.merged.nodup.no_chrM_MT.bam"
+    ],
+    "atac.read_len" : [76, 76],
+    "atac.paired_end" : true,
+    "atac.auto_detect_adapter" : true,
+    "atac.enable_xcor" : true,
+    "atac.title" : "ENCSR356KRQ (subsampled 1/400, staring from NODUP_BAMs with specified read_len)",
+    "atac.description" : "ATAC-seq on primary keratinocytes in day 0.0 of differentiation"
+}

--- a/example_input_json/template.full.json
+++ b/example_input_json/template.full.json
@@ -44,7 +44,6 @@
 
     "atac.enable_xcor" : false,
     "atac.enable_count_signal_track" : false,
-    "atac.keep_irregular_chr_in_bfilt_peak" : false,        
 
     "atac.filter_chrs" : ["chrM", "MT"],
 

--- a/src/encode_task_qc_report.py
+++ b/src/encode_task_qc_report.py
@@ -240,7 +240,7 @@ MAP_KEY_DESC_GENERAL = {
     'aligner': 'Aligner',
     'peak_caller': 'Peak caller',
     'genome': 'Genome',
-    'read_end': 'Read end'
+    'seq_endedness': 'Sequencing endedness'
 }
 
 
@@ -260,15 +260,15 @@ def make_cat_root(args):
         ('pipeline_type', args.pipeline_type),
         ('genome', args.genome),
         ('aligner', args.aligner),
-        ('read_end', OrderedDict()),
+        ('seq_endedness', OrderedDict()),
         ('peak_caller', args.peak_caller),
     ])
     if args.paired_ends is not None:
         for i, paired_end in enumerate(args.paired_ends):
-            d_general['read_end']['rep{}'.format(i + 1)] = {'paired_end': paired_end}
+            d_general['seq_endedness']['rep{}'.format(i + 1)] = {'paired_end': paired_end}
     if args.ctl_paired_ends is not None:
         for i, paired_end in enumerate(args.ctl_paired_ends):
-            d_general['read_end']['ctl{}'.format(i + 1)] = {'paired_end': paired_end}
+            d_general['seq_endedness']['ctl{}'.format(i + 1)] = {'paired_end': paired_end}
     cat_root.add_log(d_general, key='general')
 
     return cat_root

--- a/src/encode_task_qc_report.py
+++ b/src/encode_task_qc_report.py
@@ -191,21 +191,11 @@ def parse_arguments():
         if isinstance(value, list):
             setattr(args, a, split_entries_and_extend(value))
 
-    if args.paired_ends is None:
-        if args.paired_end:
-            args.paired_ends = [True]*20
-        else:
-            args.paired_ends = [False]*20
-    else:
+    if args.paired_ends is not None:
         for i, _ in enumerate(args.paired_ends):
             args.paired_ends[i] = str2bool(args.paired_ends[i])
 
-    if args.ctl_paired_ends is None:
-        if args.ctl_paired_end:
-            args.ctl_paired_ends = [True]*20
-        else:
-            args.ctl_paired_ends = args.paired_ends
-    else:
+    if args.ctl_paired_ends is not None:
         for i, _ in enumerate(args.ctl_paired_ends):
             args.ctl_paired_ends[i] = str2bool(args.ctl_paired_ends[i])
 
@@ -250,8 +240,7 @@ MAP_KEY_DESC_GENERAL = {
     'aligner': 'Aligner',
     'peak_caller': 'Peak caller',
     'genome': 'Genome',
-    'paired_end': 'Paired-end per replicate',
-    'ctl_paired_end': 'Control paired-end per replicate',
+    'read_end': 'Read end'
 }
 
 
@@ -270,13 +259,16 @@ def make_cat_root(args):
         ('pipeline_ver', args.pipeline_ver),
         ('pipeline_type', args.pipeline_type),
         ('genome', args.genome),
-        ('paired_end', args.paired_ends),
         ('aligner', args.aligner),
+        ('read_end', OrderedDict()),
         ('peak_caller', args.peak_caller),
     ])
-    if args.ctl_paired_ends \
-            and args.pipeline_type not in ('atac', 'dnase'):
-        d_general['ctl_paired_end'] = args.ctl_paired_ends
+    if args.paired_ends is not None:
+        for i, paired_end in enumerate(args.paired_ends):
+            d_general['read_end']['rep{}'.format(i + 1)] = {'paired_end': paired_end}
+    if args.ctl_paired_ends is not None:
+        for i, paired_end in enumerate(args.ctl_paired_ends):
+            d_general['read_end']['ctl{}'.format(i + 1)] = {'paired_end': paired_end}
     cat_root.add_log(d_general, key='general')
 
     return cat_root


### PR DESCRIPTION
Bug fixes:
  - `read_len` error. Cromwell bug (`read_int()` not working on `gs://` files).
  - wrong parameters in `template.full.json`

New feature:
  - added a link for QC tool `qc2tsv` to README

Dev:
  - added a workflow test for PE (starting from NODUP_BAM and specified `read_len`)