### PR TITLE
replace perl regex with ex regex

### DIFF
--- a/scripts/install_conda_env.sh
+++ b/scripts/install_conda_env.sh
@@ -16,8 +16,8 @@ conda create -n ${CONDA_ENV_PY3} --file ${REQ_TXT_PY3} -y -c defaults -c r -c bi
 conda create -n ${CONDA_ENV_PY2} --file ${REQ_TXT_PY2} -y -c defaults -c r -c bioconda -c conda-forge
 
 echo "=== Configuring for pipeline's Conda environments ==="
-CONDA_PREFIX_PY3=$(conda env list | grep -P "\b${CONDA_ENV_PY3}\s" | awk '{if (NF==3) print $3; else print $2}')
-CONDA_PREFIX_PY2=$(conda env list | grep -P "\b${CONDA_ENV_PY2}\s" | awk '{if (NF==3) print $3; else print $2}')
+CONDA_PREFIX_PY3=$(conda env list | grep -E "\b${CONDA_ENV_PY3}[[:space:]]" | awk '{if (NF==3) print $3; else print $2}')
+CONDA_PREFIX_PY2=$(conda env list | grep -E "\b${CONDA_ENV_PY2}[[:space:]]" | awk '{if (NF==3) print $3; else print $2}')
 
 if [ ! "${CONDA_PREFIX_PY3}" -o ! "${CONDA_PREFIX_PY2}" ];
 then

--- a/scripts/update_conda_env.sh
+++ b/scripts/update_conda_env.sh
@@ -8,7 +8,7 @@ SRC_DIR=${SH_SCRIPT_DIR}/../src
 
 conda --version  # check if conda exists
 
-CONDA_PREFIX_PY3=$(conda env list | grep -P "\b${CONDA_ENV_PY3}\s" | awk '{if (NF==3) print $3; else print $2}')
+CONDA_PREFIX_PY3=$(conda env list | grep -E "\b${CONDA_ENV_PY3}[[:space:]]" | awk '{if (NF==3) print $3; else print $2}')
 
 if [ ! "${CONDA_PREFIX_PY3}" ];
 then


### PR DESCRIPTION
Unlike GNU `grep` on most Linux platforms (e.g. Ubuntu). OSX's default `grep` does not have a parameter `-P`, which allows use of Perl-style reg-ex.

Pipeline's Conda environment installer scripts fail on OSX since they have `grep -P`.

Replace `grep -P` (PCRE: Perl-style extended RE)  with `grep -E` (ERE: extended RE) and also replace `\s` with a RE class `[[:space:]]`.