### PR TITLE
Pip 917 subsample ctl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
               json=${wdl%.*}.json
               result=${wdl%.*}.result.json
               ./test.sh ${wdl} ${json} ${TAG}
-              if [ -s "${result}" ]; then
+              if [[ $(wc -l "${result}" | awk '{print $1}') > 1 ]]; then
                 python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
               fi
               rm -f ${result}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,9 @@ jobs:
               json=${wdl%.*}.json
               result=${wdl%.*}.result.json
               ./test.sh ${wdl} ${json} ${TAG}
-              python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
+              if [ -s "${result}" ]; then
+                python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
+              fi
               rm -f ${result}
             done
             

--- a/dev/test/test_task/test.sh
+++ b/dev/test/test_task/test.sh
@@ -50,6 +50,6 @@ fi
 java -Dconfig.file=${BACKEND_CONF} -Dbackend.default=${BACKEND} ${EXTRA_PARAM} -jar ${CROMWELL_JAR} run ${WDL} -i ${INPUT} ${WF_OPT} -m ${METADATA}
 
 # parse output metadata json
-cat ${METADATA} | python3 -c "import json,sys;obj=json.load(sys.stdin);key='${PREFIX}.compare_md5sum.json_str';(key in obj['outputs']) and print(obj['outputs'][key])" > ${RESULT}
+cat ${METADATA} | python -c "import json,sys;obj=json.load(sys.stdin);key='${PREFIX}.compare_md5sum.json_str';print(obj['outputs'][key] if key in obj['outputs'] else '')" > ${RESULT}
 cat ${RESULT}
 rm -f ${METADATA} ${TMP_WF_OPT}

--- a/dev/test/test_task/test.sh
+++ b/dev/test/test_task/test.sh
@@ -50,6 +50,6 @@ fi
 java -Dconfig.file=${BACKEND_CONF} -Dbackend.default=${BACKEND} ${EXTRA_PARAM} -jar ${CROMWELL_JAR} run ${WDL} -i ${INPUT} ${WF_OPT} -m ${METADATA}
 
 # parse output metadata json
-cat ${METADATA} | python -c "import json,sys;obj=json.load(sys.stdin);print(obj['outputs']['${PREFIX}.compare_md5sum.json_str'])" > ${RESULT}
+cat ${METADATA} | python3 -c "import json,sys;obj=json.load(sys.stdin);key='${PREFIX}.compare_md5sum.json_str';(key in obj['outputs']) and print(obj['outputs'][key])" > ${RESULT}
 cat ${RESULT}
 rm -f ${METADATA} ${TMP_WF_OPT}

--- a/dev/test/test_task/test_bam2ta.json
+++ b/dev/test/test_task/test_bam2ta.json
@@ -4,7 +4,7 @@
 
     "test_bam2ta.ref_pe_ta" : "atac-seq-pipeline-test-data/ref_output/test_bam2ta/pe/ENCFF341MYG.subsampled.400.trim.merged.nodup.tn5.tagAlign.gz",
     "test_bam2ta.ref_pe_ta_disable_tn5_shift" : "atac-seq-pipeline-test-data/ref_output/test_bam2ta/pe/disable_tn5_shift/ENCFF341MYG.subsampled.400.trim.merged.nodup.tagAlign.gz",
-    "test_bam2ta.ref_pe_ta_subsample" : "atac-seq-pipeline-test-data/ref_output/test_bam2ta/pe/subsample/ENCFF341MYG.subsampled.400.trim.merged.nodup.5K.tn5.tagAlign.gz",
+    "test_bam2ta.ref_pe_ta_subsample" : "atac-seq-pipeline-test-data/ref_output/test_bam2ta/pe/subsample/fix_PIP-917/ENCFF341MYG.subsampled.400.trim.merged.nodup.5K.tn5.tagAlign.gz",
 
     "test_bam2ta.ref_se_ta" : "atac-seq-pipeline-test-data/ref_output/test_bam2ta/se/ENCFF439VSY.subsampled.400.trim.merged.nodup.tn5.tagAlign.gz",
     "test_bam2ta.ref_se_ta_disable_tn5_shift" : "atac-seq-pipeline-test-data/ref_output/test_bam2ta/se/disable_tn5_shift/ENCFF439VSY.subsampled.400.trim.merged.nodup.tagAlign.gz",

--- a/dev/test/test_task/test_xcor.json
+++ b/dev/test/test_task/test_xcor.json
@@ -3,7 +3,7 @@
     "test_xcor.se_ta" : "atac-seq-pipeline-test-data/input/se/tas/rep1/ENCFF439VSY.subsampled.400.trim.merged.nodup.tn5.tagAlign.gz",
 
     "test_xcor.ref_pe_xcor_log" : "atac-seq-pipeline-test-data/ref_output/test_xcor/pe/ENCFF341MYG.subsampled.400.trim.merged.nodup.tn5.no_chrM.R1.25M.cc.qc",
-    "test_xcor.ref_pe_xcor_log_subsample" : "atac-seq-pipeline-test-data/ref_output/test_xcor/pe/subsample/ENCFF341MYG.subsampled.400.trim.merged.nodup.tn5.no_chrM.R1.5K.cc.qc",
+    "test_xcor.ref_pe_xcor_log_subsample" : "atac-seq-pipeline-test-data/ref_output/test_xcor/pe/subsample/fix_PIP-917/ENCFF341MYG.subsampled.400.trim.merged.nodup.tn5.no_chrM.R1.5K.cc.qc",
     "test_xcor.ref_se_xcor_log" : "atac-seq-pipeline-test-data/ref_output/test_xcor/se/ENCFF439VSY.subsampled.400.trim.merged.nodup.tn5.25M.cc.qc",
     "test_xcor.ref_se_xcor_log_subsample" : "atac-seq-pipeline-test-data/ref_output/test_xcor/se/subsample/ENCFF439VSY.subsampled.400.trim.merged.nodup.tn5.no_chrM.5K.cc.qc",
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -162,7 +162,7 @@ Parameter|Default|Description
 
 Parameter|Default|Description
 ---------|-------|-----------
-`atac.subsample_reads` | 0 | Subsample reads (0: no subsampling). Subsampled reads will be used for all downsteam analyses including peak-calling
+`atac.subsample_reads` | 0 | Subsample reads (0: no subsampling). For PE dataset, this is not a number of read pairs but number of reads. Subsampled reads will be used for all downsteam analyses including peak-calling
 `atac.xcor_subsample_reads` | 15000000 | Subsample reads for cross-corr. analysis only (0: no subsampling). Subsampled reads will be used for cross-corr. analysis only
 
 ## Optional peak-calling parameters

--- a/docs/input_short.md
+++ b/docs/input_short.md
@@ -50,7 +50,7 @@ Mandatory parameters:
 Optional parameters:
 
 8) Useful parameters
-    * `atac.subsample_reads`: Subsample reads. This will affect all downsteam analyses including peak-calling. It's 0 by default, which means no subsampling.
+    * `atac.subsample_reads`: Subsample reads. For PE dataset, this is not a number of read pairs but number of reads. This will affect all downsteam analyses including peak-calling. It's 0 by default, which means no subsampling.
 
 9) Flags
     * `atac.align_only`: Peak calling and its downstream analyses will be disabled. Useful if you just want to align your FASTQs into filtered BAMs/TAG-ALIGNs and don't want to call peaks on them.

--- a/src/encode_lib_genomic.py
+++ b/src/encode_lib_genomic.py
@@ -281,7 +281,7 @@ def subsample_ta_pe(ta, subsample, non_mito, mito_chr_name, r1_only, out_dir):
         cmd0 += '</dev/zero 2>/dev/null) > {}'
         cmd0 = cmd0.format(
             ta,
-            subsample % 2,
+            int(subsample / 2),
             ta,
             ta_tmp)
     else:

--- a/src/encode_lib_genomic.py
+++ b/src/encode_lib_genomic.py
@@ -258,6 +258,10 @@ def subsample_ta_se(ta, subsample, non_mito, mito_chr_name, out_dir):
 def subsample_ta_pe(ta, subsample, non_mito, mito_chr_name, r1_only, out_dir):
     prefix = os.path.join(out_dir,
                           os.path.basename(strip_ext_ta(ta)))
+    if subsample % 2:
+        raise ValueError(
+            'Number of reads to subsample should be an even number '
+            'for paired end TAG-ALIGN (BED) file. n={n}'.format(n=subsample))
     ta_subsampled = '{}.{}{}{}tagAlign.gz'.format(
         prefix,
         'no_chrM.' if non_mito else '',
@@ -277,7 +281,7 @@ def subsample_ta_pe(ta, subsample, non_mito, mito_chr_name, r1_only, out_dir):
         cmd0 += '</dev/zero 2>/dev/null) > {}'
         cmd0 = cmd0.format(
             ta,
-            subsample,
+            subsample % 2,
             ta,
             ta_tmp)
     else:

--- a/src/encode_task_macs2_chip.py
+++ b/src/encode_task_macs2_chip.py
@@ -9,6 +9,7 @@ import argparse
 from encode_lib_common import (
     assert_file_not_empty, human_readable_number,
     log, ls_l, mkdir_p, rm_f, run_shell_cmd, strip_ext_ta)
+from encode_lib_genomic import subsample_ta_se, subsample_ta_pe
 
 
 def parse_arguments():
@@ -31,6 +32,11 @@ def parse_arguments():
                         help='P-Value threshold.')
     parser.add_argument('--cap-num-peak', default=500000, type=int,
                         help='Capping number of peaks by taking top N peaks.')
+    parser.add_argument('--ctl-subsample', default=0, type=int,
+                        help='Subsample control to this read depth '
+                             '(0: no subsampling).')
+    parser.add_argument('--ctl-paired-end', action="store_true",
+                        help='Paired-end control TA.')
     parser.add_argument('--out-dir', default='', type=str,
                         help='Output directory.')
     parser.add_argument('--log-level', default='INFO',
@@ -47,9 +53,21 @@ def parse_arguments():
 
 
 def macs2(ta, ctl_ta, chrsz, gensz, pval_thresh, shift, fraglen, cap_num_peak,
-          out_dir):
+          ctl_subsample, ctl_paired_end, out_dir):
     basename_ta = os.path.basename(strip_ext_ta(ta))
     if ctl_ta:
+        if ctl_subsample:
+            if ctl_paired_end:
+                ctl_ta = subsample_ta_pe(
+                    ctl_ta, ctl_subsample,
+                    non_mito=False, mito_chr_name=None, r1_only=False,
+                    out_dir=out_dir)
+            else:
+                ctl_ta = subsample_ta_se(
+                    ctl_ta, ctl_subsample,
+                    non_mito=False, mito_chr_name=None,
+                    out_dir=out_dir)
+
         basename_ctl_ta = os.path.basename(strip_ext_ta(ctl_ta))
         basename_prefix = '{}_x_{}'.format(basename_ta, basename_ctl_ta)
         if len(basename_prefix) > 200:  # UNIX cannot have len(filename) > 255
@@ -110,7 +128,8 @@ def main():
     log.info('Calling peaks with macs2...')
     npeak = macs2(
         args.tas[0], args.tas[1], args.chrsz, args.gensz, args.pval_thresh,
-        args.shift, args.fraglen, args.cap_num_peak, args.out_dir)
+        args.shift, args.fraglen, args.cap_num_peak,
+        args.ctl_subsample, args.ctl_paired_end, args.out_dir)
 
     log.info('Checking if output is empty...')
     assert_file_not_empty(npeak)

--- a/src/encode_task_macs2_signal_track_chip.py
+++ b/src/encode_task_macs2_signal_track_chip.py
@@ -8,6 +8,7 @@ import os
 import argparse
 from encode_lib_common import (
     get_num_lines, log, ls_l, mkdir_p, rm_f, run_shell_cmd, strip_ext_ta)
+from encode_lib_genomic import subsample_ta_se, subsample_ta_pe
 
 
 def parse_arguments():
@@ -26,6 +27,11 @@ def parse_arguments():
                             chr. sizes file, or hs for human, ms for mouse).')
     parser.add_argument('--pval-thresh', default=0.01, type=float,
                         help='P-Value threshold.')
+    parser.add_argument('--ctl-subsample', default=0, type=int,
+                        help='Subsample control to this read depth '
+                             '(0: no subsampling).')
+    parser.add_argument('--ctl-paired-end', action="store_true",
+                        help='Paired-end control TA.')
     parser.add_argument('--out-dir', default='', type=str,
                         help='Output directory.')
     parser.add_argument('--log-level', default='INFO',
@@ -41,9 +47,21 @@ def parse_arguments():
     return args
 
 
-def macs2_signal_track(ta, ctl_ta, chrsz, gensz, pval_thresh, shift, fraglen, out_dir):
+def macs2_signal_track(ta, ctl_ta, chrsz, gensz, pval_thresh, shift, fraglen,
+                       ctl_subsample, ctl_paired_end, out_dir):
     basename_ta = os.path.basename(strip_ext_ta(ta))
     if ctl_ta:
+        if ctl_subsample:
+            if ctl_paired_end:
+                ctl_ta = subsample_ta_pe(
+                    ctl_ta, ctl_subsample,
+                    non_mito=False, mito_chr_name=None, r1_only=False,
+                    out_dir=out_dir)
+            else:
+                ctl_ta = subsample_ta_se(
+                    ctl_ta, ctl_subsample,
+                    non_mito=False, mito_chr_name=None,
+                    out_dir=out_dir)
         basename_ctl_ta = os.path.basename(strip_ext_ta(ctl_ta))
         basename_prefix = '{}_x_{}'.format(basename_ta, basename_ctl_ta)
         if len(basename_prefix) > 200:  # UNIX cannot have len(filename) > 255
@@ -169,7 +187,8 @@ def main():
     log.info('Calling peaks and generating signal tracks with MACS2...')
     fc_bigwig, pval_bigwig = macs2_signal_track(
         args.tas[0], args.tas[1], args.chrsz, args.gensz, args.pval_thresh,
-        args.shift, args.fraglen, args.out_dir)
+        args.shift, args.fraglen, args.ctl_subsample, args.ctl_paired_end,
+        args.out_dir)
 
     log.info('List all files in output directory...')
     ls_l(args.out_dir)

--- a/src/encode_task_pool_ta.py
+++ b/src/encode_task_pool_ta.py
@@ -36,8 +36,8 @@ def parse_arguments():
 
 def pool_ta(tas, col, basename_prefix, out_dir):
     if len(tas) > 1:
-        if basename_prefix is None:
-            prefix = os.path.join(out_dir,'basename_prefix')
+        if basename_prefix is not None:
+            prefix = os.path.join(out_dir, basename_prefix)
         else:
             prefix = os.path.join(out_dir,
                               os.path.basename(strip_ext_ta(tas[0])))


### PR DESCRIPTION
Just to sync shared task wrappers `.py`s with chip-seq-pipeline.
https://github.com/ENCODE-DCC/chip-seq-pipeline2/pull/145

Important bug fix for PE subsampling TAG-ALIGN
- Every two lines in PE TAG-ALIGN are paired. So subsampling converts PE TA into BEDPE format by merging every two lines in TAG-ALIGN and then do subsampling on BEDPE and then converts subsampled BEDPE back to PE TA.
- Input to the subsampling function `subsample_ta_pe()` takes in `subsample` (number of reads to subsample). This `subsample` should have been halved since actual `shuf`fliing is done on BEDPE (with half number of lines than the original TA). https://github.com/ENCODE-DCC/chip-seq-pipeline2/pull/145/commits/8d39c0ec71b80259c27fb2792de83a62d8b3c4d7#diff-d18e1add369d9d400431efb63877da22R284
- So this bug works like `subsample` parameter is doubled for PE dataset.
- Default settings of the pipeline is not affected by this bug.
- Affected cases:
  - `atac.subsample_reads > 0` (0 by default) and `atac.paired_end == True` and actual number of reads in replicate is > `atac.subsample_reads`.
  - `atac.enable_xcor == True` (disabled by default) and `atac.xcor_subsample_reads > 0` (25M by default) and `atac.paired_end == True` and actual number of reads in replicate is > `atac.xcor_subsample_reads`. 

Other bug fixes
- Pooled TA filename