### PR TITLE
Pip 1056 wdl 1.0

### DIFF
--- a/atac.croo.v4.json
+++ b/atac.croo.v4.json
@@ -106,10 +106,6 @@
     "score": {
       "path": "qc/rep${i+1}/${basename}",
       "table": "QC and logs/Replicate ${i+1}/Cross-correlation score"
-    },
-    "fraglen": {
-      "path": "qc/rep${i+1}/${basename}",
-      "table": "QC and logs/Replicate ${i+1}/Estimated fragment length"
     }
   },
   "atac.call_peak": {

--- a/atac.wdl
+++ b/atac.wdl
@@ -1,248 +1,837 @@
-#CAPER docker quay.io/encode-dcc/atac-seq-pipeline:v1.7.1
-#CAPER singularity docker://quay.io/encode-dcc/atac-seq-pipeline:v1.7.1
-#CROO out_def https://storage.googleapis.com/encode-pipeline-output-definition/atac.croo.v4.json
+version 1.0
 
 workflow atac {
+	String pipeline_ver = 'v1.7.1'
+
 	meta {
 		author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
 		description: 'ATAC-Seq/DNase-Seq pipeline'
+		specification_document: 'https://docs.google.com/document/d/1f0Cm4vRyDQDu0bMehHD7P7KOMxTOP-HiNoIvL1VcBt8/edit?usp=sharing'
 
 		caper_docker: 'quay.io/encode-dcc/atac-seq-pipeline:v1.7.1'
 		caper_singularity: 'docker://quay.io/encode-dcc/atac-seq-pipeline:v1.7.1'
 		croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/atac.croo.v4.json'
 	}
-	# pipeline version
-	String pipeline_ver = 'v1.7.1'
+	input {
+		# group: pipeline_metadata
+		String title = 'Untitled'
+		String description = 'No description'
 
-	# general sample information
-	String title = 'Untitled'
-	String description = 'No description'
+		# group: reference_genome
+		File? genome_tsv
+		String? genome_name
+		File? ref_fa
+		File? ref_mito_fa
+		File? bowtie2_idx_tar
+		File? bowtie2_mito_idx_tar
+		File? chrsz
+		File? blacklist
+		File? blacklist2
+		String? mito_chr_name
+		String? regex_bfilt_peak_chr_name
+		String? gensz
+		File? tss
+		File? dnase
+		File? prom
+		File? enh
+		File? reg2map
+		File? reg2map_bed
+		File? roadmap_meta
 
-	# endedness for input data
-	Boolean? paired_end				# to define endedness for all replciates
-									#	if defined, this will override individual endedness below
-	Array[Boolean] paired_ends = []	# to define endedness for individual replicate
+		# group: input_genomic_data
+		Boolean? paired_end
+		Array[Boolean] paired_ends = []
+		Array[File] fastqs_rep1_R1 = []
+		Array[File] fastqs_rep1_R2 = []
+		Array[File] fastqs_rep2_R1 = []
+		Array[File] fastqs_rep2_R2 = []
+		Array[File] fastqs_rep3_R1 = []
+		Array[File] fastqs_rep3_R2 = []
+		Array[File] fastqs_rep4_R1 = []
+		Array[File] fastqs_rep4_R2 = []
+		Array[File] fastqs_rep5_R1 = []
+		Array[File] fastqs_rep5_R2 = []
+		Array[File] fastqs_rep6_R1 = []
+		Array[File] fastqs_rep6_R2 = []
+		Array[File] fastqs_rep7_R1 = []
+		Array[File] fastqs_rep7_R2 = []
+		Array[File] fastqs_rep8_R1 = []
+		Array[File] fastqs_rep8_R2 = []
+		Array[File] fastqs_rep9_R1 = []
+		Array[File] fastqs_rep9_R2 = []
+		Array[File] fastqs_rep10_R1 = []
+		Array[File] fastqs_rep10_R2 = []
+		Array[File?] bams = []
+		Array[File?] nodup_bams = []
+		Array[File?] tas = []
+		Array[File?] peaks = []
+		Array[File?] peaks_pr1 = []
+		Array[File?] peaks_pr2 = []
+		File? peak_pooled
+		File? peak_ppr1
+		File? peak_ppr2
 
-	# genome TSV
-	# 	you can define any genome parameters either in this TSV
-	#	or individually in an input JSON file
-	# 	individually defined parameters will override those defined in this TSV	
-	File? genome_tsv 				# reference genome data TSV file including
-									# all genome-specific file paths and parameters
-	# individual genome parameters
-	String? genome_name				# genome name
-	File? ref_fa					# reference fasta (*.fa.gz)
-	File? ref_mito_fa				# mito-only reference fasta (*.fa.gz)
-	File? bwa_idx_tar 				# bwa index tar (uncompressed .tar)
-	File? bwa_mito_idx_tar 			# bwa mito-only index tar (uncompressed .tar)
-	File? bowtie2_idx_tar 			# bowtie2 index tar (uncompressed .tar)
-	File? bowtie2_mito_idx_tar 		# bowtie2 mito-only index tar (uncompressed .tar)
-	File? custom_aligner_idx_tar 	# custom aligner's index tar (uncompressed .tar)
-	File? custom_aligner_mito_idx_tar 	# custom aligner's mito-only index tar (uncompressed .tar)
-	File? chrsz 					# 2-col chromosome sizes file
-	File? blacklist 				# blacklist BED (peaks overlapping will be filtered out)
-	File? blacklist2 				# 2nd blacklist (will be merged with 1st one)
-	String? mito_chr_name
-	String? regex_bfilt_peak_chr_name
-	String? gensz 					# genome sizes (hs for human, mm for mouse or sum of 2nd col in chrsz)
-	File? tss 						# TSS BED file
-	File? dnase 					# open chromatin region BED file
-	File? prom 						# promoter region BED file
-	File? enh 						# enhancer region BED file
-	File? reg2map 					# file with cell type signals
-	File? reg2map_bed 				# file of regions used to generate reg2map signals
-	File? roadmap_meta 				# roadmap metedata
+		# group: pipeline_parameter
+		String pipeline_type = 'atac'
+		Boolean align_only = false
+		Boolean true_rep_only = false
+		Boolean enable_xcor = false
+		Boolean enable_count_signal_track = false
+		Boolean enable_idr = true
+		Boolean enable_preseq = false
+		Boolean enable_fraglen_stat = true
+		Boolean enable_tss_enrich = true
+		Boolean enable_annot_enrich = true
+		Boolean enable_jsd = true
+		Boolean enable_compare_to_roadmap = false
+		Boolean enable_gc_bias = true
 
-	# parameters for pipeline
-	String pipeline_type = 'atac'	# atac (default), dnase (same as atac but no tn5 shifting)
+		# group: adapter_trimming
+		String cutadapt_param = '-e 0.1 -m 5'
+		Boolean auto_detect_adapter = false
+		String? adapter
+		Array[String] adapters_rep1_R1 = []
+		Array[String] adapters_rep1_R2 = []
+		Array[String] adapters_rep2_R1 = []
+		Array[String] adapters_rep2_R2 = []
+		Array[String] adapters_rep3_R1 = []
+		Array[String] adapters_rep3_R2 = []
+		Array[String] adapters_rep4_R1 = []
+		Array[String] adapters_rep4_R2 = []
+		Array[String] adapters_rep5_R1 = []
+		Array[String] adapters_rep5_R2 = []
+		Array[String] adapters_rep6_R1 = []
+		Array[String] adapters_rep6_R2 = []
+		Array[String] adapters_rep7_R1 = []
+		Array[String] adapters_rep7_R2 = []
+		Array[String] adapters_rep8_R1 = []
+		Array[String] adapters_rep8_R2 = []
+		Array[String] adapters_rep9_R1 = []
+		Array[String] adapters_rep9_R2 = []
+		Array[String] adapters_rep10_R1 = []
+		Array[String] adapters_rep10_R2 = []
 
-	String aligner = 'bowtie2' 		# supported aligner: bowtie2
-	File? custom_align_py 			# custom align python script
+		# group: alignment
+		Int multimapping = 4
+		String dup_marker = 'picard'
+		Boolean no_dup_removal = false
+		Int mapq_thresh = 30
+		Array[String] filter_chrs = ['chrM', 'MT']
+		Int subsample_reads = 0
+		Int xcor_subsample_reads = 25000000
+		Array[Int?] read_len = []
 
+		# group: peak_calling
+		Int cap_num_peak = 300000
+		Float pval_thresh = 0.01
+		Int smooth_win = 150
+		Float idr_thresh = 0.05
+
+		# group: resource_parameter
+		Int align_cpu = 4
+		Int align_mem_mb = 20000
+		Int align_time_hr = 48
+		String align_disks = 'local-disk 400 HDD'
+
+		Int filter_cpu = 2
+		Int filter_mem_mb = 20000
+		Int filter_time_hr = 24
+		String filter_disks = 'local-disk 400 HDD'
+
+		Int bam2ta_cpu = 2
+		Int bam2ta_mem_mb = 10000
+		Int bam2ta_time_hr = 6
+		String bam2ta_disks = 'local-disk 100 HDD'
+
+		Int spr_mem_mb = 16000
+
+		Int jsd_cpu = 2
+		Int jsd_mem_mb = 12000
+		Int jsd_time_hr = 6
+		String jsd_disks = 'local-disk 200 HDD'
+
+		Int xcor_cpu = 2
+		Int xcor_mem_mb = 16000
+		Int xcor_time_hr = 6
+		String xcor_disks = 'local-disk 100 HDD'
+
+		Int call_peak_cpu = 1
+		Int call_peak_mem_mb = 16000
+		Int call_peak_time_hr = 24
+		String call_peak_disks = 'local-disk 200 HDD'
+
+		Int macs2_signal_track_mem_mb = 16000
+		Int macs2_signal_track_time_hr = 24
+		String macs2_signal_track_disks = 'local-disk 400 HDD'
+
+		Int preseq_mem_mb = 16000
+
+		String? filter_picard_java_heap
+		String? preseq_picard_java_heap
+		String? fraglen_stat_picard_java_heap
+		String? gc_bias_picard_java_heap
+	}
+
+	parameter_meta {
+		title: {
+			description: 'Experiment title.',
+			group: 'pipeline_metadata',
+		}
+		description: {
+			description: 'Experiment description.',
+			group: 'pipeline_metadata',
+		}
+		genome_tsv: {
+			description: 'Reference genome database TSV.',
+			group: 'reference_genome',
+			help: 'This TSV files includes all genome specific parameters (e.g. reference FASTA, bowtie2 index). You can still invidiaully define any parameters in it. Parameters defined in input JSON will override those defined in genome TSV.'
+		}
+		genome_name: {
+			description: 'Genome name.',
+			group: 'reference_genome'
+		}
+		ref_fa: {
+			description: 'Reference FASTA file.',
+			group: 'reference_genome'
+		}
+		ref_mito_fa: {
+			description: 'Reference FASTA file (mitochondrial reads only).',
+			group: 'reference_genome'
+		}
+		bowtie2_idx_tar: {
+			description: 'BWA index TAR file.',
+			group: 'reference_genome'
+		}
+		bowtie2_mito_idx_tar: {
+			description: 'BWA index TAR file (mitochondrial reads only).',
+			group: 'reference_genome'
+		}
+		chrsz: {
+			description: '2-col chromosome sizes file.',
+			group: 'reference_genome'
+		}
+		blacklist: {
+			description: 'Blacklist file in BED format.',
+			group: 'reference_genome',
+			help: 'Peaks will be filtered with this file.'
+		}
+		blacklist2: {
+			description: 'Secondary blacklist file in BED format.',
+			group: 'reference_genome',
+			help: 'If it is defined, it will be merged with atac.blacklist. Peaks will be filtered with merged blacklist.'
+		}
+		mito_chr_name: {
+			description: 'Mitochondrial chromosome name.',
+			group: 'reference_genome',
+			help: 'e.g. chrM, MT. Mitochondrial reads defined here will be filtered out during filtering BAMs in "filter" task.'
+		}
+		regex_bfilt_peak_chr_name: {
+			description: 'Reg-ex for chromosomes to keep while filtering peaks.',
+			group: 'reference_genome',
+			help: 'Chromosomes defined here will be kept. All other chromosomes will be filtered out in .bfilt. peak file. This is done along with blacklist filtering peak file.'
+		}
+		gensz: {
+			description: 'Genome sizes. "hs" for human, "mm" for mouse or sum of 2nd columnin chromosome sizes file.',
+			group: 'reference_genome'
+		}
+		tss: {
+			description: 'TSS file in BED format.',
+			group: 'reference_genome'
+		}
+		dnase: {
+			description: 'Open chromatin regions file in BED format.',
+			group: 'reference_genome'
+		}
+		prom: {
+			description: 'Promoter regions file in BED format.',
+			group: 'reference_genome'
+		}
+		enh: {
+			description: 'Enhancer regions file in BED format.',
+			group: 'reference_genome'
+		}
+		reg2map: {
+			description: 'Cell type signals file.',
+			group: 'reference_genome'
+		}
+		reg2map_bed: {
+			description: 'File of regions used to generate reg2map signals.',
+			group: 'reference_genome'
+		}
+		roadmap_meta: {
+			description: 'Roadmap metadata.',
+			group: 'reference_genome'
+		}
+		paired_end: {
+			description: 'Sequencing endedness.',
+			group: 'input_genomic_data',
+			help: 'Setting this on means that all replicates are paired ended. For mixed samples, use atac.paired_ends array instead.'
+		}
+		paired_ends: {
+			description: 'Sequencing endedness array (for mixed SE/PE datasets).',
+			group: 'input_genomic_data',
+			help: 'Whether each biological replicate is paired ended or not.'
+		}
+		fastqs_rep1_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of inputs (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined. Especially for FASTQs, we have individual variable for each biological replicate to allow FASTQs of technical replicates can be merged. Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep1_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep1_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep2_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 2.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep2_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 2.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep3_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 3.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep3_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 3.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep4_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 4.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep4_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 4.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep5_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 5.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep5_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 5.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep6_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 6.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep6_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 6.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep7_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 7.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep7_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep7_R2: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 7.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep7_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep8_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 8.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep8_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep8_R2: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 8.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep8_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep9_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 9.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep9_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep9_R2: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 9.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep9_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep10_R1: {
+			description: 'Read1 FASTQs to be merged for a biological replicate 10.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep10_R2). These FASTQs are usually technical replicates to be merged.'
+		}
+		fastqs_rep10_R2: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 10.',
+			group: 'input_genomic_data',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep10_R1). These FASTQs are usually technical replicates to be merged.'
+		}
+		bams: {
+			description: 'List of unfiltered/raw BAM files for each biological replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from BAM files. Unfiltered/raw BAM file generated from aligner (e.g. bowtie2). Each entry for each biological replicate. e.g. [rep1.bam, rep2.bam, rep3.bam, ...].'
+		}
+		nodup_bams: {
+			description: 'List of filtered/deduped BAM files for each biological replicate',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from filtered BAM files. Filtered/deduped BAM file. Each entry for each biological replicate. e.g. [rep1.nodup.bam, rep2.nodup.bam, rep3.nodup.bam, ...].'
+		}
+		tas: {
+			description: 'List of TAG-ALIGN files for each biological replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from TAG-ALIGN files. TAG-ALIGN is in a 6-col BED format. It is a simplified version of BAM. Each entry for each biological replicate. e.g. [rep1.tagAlign.gz, rep2.tagAlign.gz, ...].'
+		}
+		peaks: {
+			description: 'List of NARROWPEAK files (not blacklist filtered) for each biological replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Each entry for each biological replicate. e.g. [rep1.narrowPeak.gz, rep2.narrowPeak.gz, ...]. Define other PEAK parameters (e.g. atac.peaks_pr1, atac.peak_pooled) according to your flag settings (e.g. atac.true_rep_only) and number of replicates. If you have more than one replicate then define atac.peak_pooled, atac.peak_ppr1 and atac.peak_ppr2. If atac.true_rep_only flag is on then do not define any parameters (atac.peaks_pr1, atac.peaks_pr2, atac.peak_ppr1 and atac.peak_ppr2) related to pseudo replicates.'
+		}
+		peaks_pr1: {
+			description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 1 of each biological replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Define if atac.true_rep_only flag is off.'
+		}
+		peaks_pr2: {
+			description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 2 of each biological replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Define if atac.true_rep_only flag is off.'
+		}
+		peak_pooled: {
+			description: 'NARROWPEAK file for pooled true replicate.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates. Pooled true replicate means analysis on pooled biological replicates.'
+		}
+		peak_ppr1: {
+			description: 'NARROWPEAK file for pooled pseudo replicate 1.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and atac.truerep_only flag is off. PPR1 means analysis on pooled 1st pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 1st pseudos.'
+		}
+		peak_ppr2: {
+			description: 'NARROWPEAK file for pooled pseudo replicate 2.',
+			group: 'input_genomic_data',
+			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and atac.truerep_only flag is off. PPR1 means analysis on pooled 2nd pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 2nd pseudos.'
+		}
+
+		pipeline_type: {
+			description: 'Pipeline type. atac for ATAC-Seq or dnase for DNase-Seq.',
+			group: 'pipeline_parameter',
+			help: 'The only difference of two types is that TN5 shifting of TAG-ALIGN is done for atac. TAG-ALIGN is in 6-col BED format. It is a simplified version of BAM.'
+		}
+		align_only: {
+			description: 'Align only mode.',
+			group: 'pipeline_parameter',
+			help: 'Reads will be aligned but there will be no peak-calling on them.'
+		}
+		true_rep_only: {
+			description: 'Disables all analyses related to pseudo-replicates.',
+			group: 'pipeline_parameter',
+			help: 'Pipeline generates 2 pseudo-replicate from one biological replicate. This flag turns off all analyses related to pseudos (with prefix/suffix pr, ppr).'
+		}
+		enable_xcor: {
+			description: 'Enables cross-correlation analysis.',
+			group: 'pipeline_parameter',
+			help: 'Generates cross-correlation plot.'
+		}
+		enable_count_signal_track: {
+			description: 'Enables generation of count signal tracks.',
+			group: 'pipeline_parameter'
+		}
+		enable_idr: {
+			description: 'Enables IDR on MACS2 NARROWPEAKs.',
+			group: 'pipeline_parameter'
+		}
+		enable_preseq: {
+			description: 'Enables preseq analysis.',
+			group: 'pipeline_parameter'
+		}
+		enable_fraglen_stat: {
+			description: 'Enables calculation of fragment length distribution/statistics.',
+			group: 'pipeline_parameter'
+		}
+		enable_tss_enrich: {
+			description: 'Enables TSS enrichment plot generation.',
+			group: 'pipeline_parameter'
+		}
+		enable_tss_enrich: {
+			description: 'Enables annotation enrichment analysis.',
+			group: 'pipeline_parameter'
+		}
+		enable_jsd: {
+			description: 'Enables Jensen-Shannon Distance (JSD) plot generation.',
+			group: 'pipeline_parameter'
+		}
+		enable_compare_to_roadmap: {
+			description: 'Enables comparison to Roadmap.',
+			group: 'pipeline_parameter'
+		}
+		enable_gc_bias: {
+			description: 'Enables GC bias calculation.',
+			group: 'pipeline_parameter'
+		}
+
+		cutadapt_param: {
+			description: 'Parameters for cutadapt.',
+			group: 'adapter_trimming',
+			help: 'It is -e 0.1 -m 5 by default (err_rate=0.1, min_trim_len=5). You can define any parameters that cutadapt supports.'
+		}
+		auto_detect_adapter: {
+			description: 'Auto-detect/trim adapter sequences.',
+			group: 'adapter_trimming',
+			help: 'Can detect three types of adapter sequences. Illumina: AGATCGGAAGAGC, Nextera: CTGTCTCTTATA, smallRNA: TGGAATTCTCGG.'
+		}
+		adapter: {
+			description: 'Adapter for all FASTQs.',
+			group: 'adapter_trimming',
+			help: 'Define if all FASTQs have the same adapter sequence. Otherwise define adapter sequence for individual FASTQ in atac.adapters_repX_R1 and atac.adapters_repX_R2 instead. Use atac.auto_detect_adapter if you want to detect adapters automatically.'
+		}
+		adapters_rep1_R1: {
+			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep1_R2). You can combine this with atac.auto_detect_adapter. Pipeline will auto-detect/trim adapter sequences for null entry in this list. e.g. ["AAGGCCTT", null, "AAGGCCTT"].'
+		}
+		adapters_rep1_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep1_R1).'
+		}
+		adapters_rep2_R1: {
+			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep2_R2).'
+		}
+		adapters_rep2_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep2_R1).'
+		}
+		adapters_rep3_R1: {
+			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep3_R2).'
+		}
+		adapters_rep3_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep3_R1).'
+		}
+		adapters_rep4_R1: {
+			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep4_R2).'
+		}
+		adapters_rep4_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep4_R1).'
+		}
+		adapters_rep5_R1: {
+			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep5_R2).'
+		}
+		adapters_rep5_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep5_R1).'
+		}
+		adapters_rep6_R1: {
+			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep6_R2).'
+		}
+		adapters_rep6_R1: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep6_R1).'
+		}
+		adapters_rep7_R1: {
+			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep7_R2).'
+		}
+		adapters_rep7_R2: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep7_R1).'
+		}
+		adapters_rep8_R1: {
+			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep8_R2).'
+		}
+		adapters_rep8_R2: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep8_R1).'
+		}
+		adapters_rep9_R1: {
+			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep9_R2).'
+		}
+		adapters_rep9_R2: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep9_R1).'
+		}
+		adapters_rep10_R1: {
+			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep10_R2).'
+		}
+		adapters_rep10_R2: {
+			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+			group: 'adapter_trimming',
+			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep10_R1).'
+		}
+
+		multimapping: {
+			description: 'Number of multimappers.',
+			group: 'alignment',
+			help: 'It is 4 by default. Set it to 0 if your sample does not have multimappers.'
+		}
+		dup_marker: {
+			description: 'Marker for duplicate reads. picard or sambamba.',
+			group: 'alignment',
+			help: 'picard for Picard MarkDuplicates or sambamba for sambamba markdup.'
+		}
+		no_dup_removal: {
+			description: 'Disable removal of duplicate reads during filtering BAM.',
+			group: 'alignment',
+			help: 'Duplicate reads are filtererd out during filtering BAMs to gerenate NODUP_BAM. This flag will keep all duplicate reads in NODUP_BAM. This flag does not affect naming of NODUP_BAM. NODUP_BAM will still have .nodup. suffix in its filename.'
+		}
+		mapq_thresh: {
+			description: 'Threshold for low MAPQ reads removal',
+			group: 'alignment',
+			help: 'Low MAPQ reads are filtered out while filtering BAM.',
+		}
+		filter_chrs: {
+			description: 'List of chromosomes to be filtered out while filtering BAM.',
+			group: 'alignment',
+			help: 'It is ["chrM", "MT"] by default. Therefore, mitochondrial reads will be filtered out while filtering. Make it empty if you want to keep all reads.'
+		}
+		subsample_reads: {
+			description: 'Subsample reads. Shuffle and subsample reads.',
+			group: 'alignment',
+			help: 'This affects all downstream analyses after filtering BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number.'
+		}
+		xcor_subsample_reads: {
+			description: 'Subsample reads for cross-corrlelation analysis only.',
+			group: 'alignment',
+			help: 'This does not affect downstream analyses after filtering BAM. It is for cross-correlation analysis only.'
+		}
+		read_len: {
+			description: 'Read length per biological replicate.',
+			group: 'alignment',
+			help: 'Pipeline can estimate read length from FASTQs. If you start pipeline from other types (BAM, NODUP_BAM, TA, ...) than FASTQ. Then provide this for some analyses that require read length (e.g. TSS enrichment plot).'
+		}
+
+		cap_num_peak: {
+			description: 'Upper limit on the number of peaks.',
+			group: 'peak_calling',
+			help: 'Called peaks will be sorted in descending order of score and the number of peaks will be capped at this number by taking first N peaks.'
+		}
+		pval_thresh: {
+			description: 'p-value Threshold for MACS2 peak caller.',
+			group: 'peak_calling',
+			help: 'macs2 callpeak -p'
+		}
+		smooth_win: {
+			description: 'Size of smoothing windows for MACS2 peak caller.',
+			group: 'peak_calling',
+			help: 'This will be used for both generating MACS2 peaks/signal tracks.'
+		}
+		idr_thresh: {
+			description: 'IDR threshold.',
+			group: 'peak_calling'
+		}
+
+		align_cpu: {
+			description: 'Number of cores for task align.',
+			group: 'resource_parameter',
+			help: 'Task align merges/crops/maps FASTQs.'
+		}
+		align_mem_mb: {
+			description: 'Memory (MB) required for task align.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		align_time_hr: {
+			description: 'Walltime (h) required for task align.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		align_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task align.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		filter_cpu: {
+			description: 'Number of cores for task filter.',
+			group: 'resource_parameter',
+			help: 'Task filter filters raw/unfilterd BAM to get filtered/deduped BAM.'
+		}
+		filter_mem_mb: {
+			description: 'Memory (MB) required for task filter.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		filter_time_hr: {
+			description: 'Walltime (h) required for task filter.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		filter_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task filter.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		bam2ta_cpu: {
+			description: 'Number of cores for task bam2ta.',
+			group: 'resource_parameter',
+			help: 'Task bam2ta converts filtered/deduped BAM in to TAG-ALIGN (6-col BED) format.'
+		}
+		bam2ta_mem_mb: {
+			description: 'Memory (MB) required for task bam2ta.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		bam2ta_time_hr: {
+			description: 'Walltime (h) required for task bam2ta.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		bam2ta_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task bam2ta.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		spr_mem_mb: {
+			description: 'Memory (MB) required for task spr.',
+			group: 'resource_parameter',
+			help: 'Task spr generates two pseudo-replicates from each biological replicate. This task uses Unix shuf/sort, which can take significant amount of memory.'
+		}
+		jsd_cpu: {
+			description: 'Number of cores for task jsd.',
+			group: 'resource_parameter',
+			help: 'Task jsd plots Jensen-Shannon distance and metrics related to it.'
+		}
+		jsd_mem_mb: {
+			description: 'Memory (MB) required for task jsd.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		jsd_time_hr: {
+			description: 'Walltime (h) required for task jsd.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		jsd_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task jsd.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		xcor_cpu: {
+			description: 'Number of cores for task xcor.',
+			group: 'resource_parameter',
+			help: 'Task xcor does cross-correlation analysis (including a plot) on subsampled TAG-ALIGNs.'
+		}
+		xcor_mem_mb: {
+			description: 'Memory (MB) required for task xcor.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		xcor_time_hr: {
+			description: 'Walltime (h) required for task xcor.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		xcor_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task xcor.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		call_peak_cpu: {
+			description: 'Number of cores for task call_peak.',
+			group: 'resource_parameter',
+			help: 'Task call_peak call peaks on TAG-ALIGNs by using MACS2 peak caller.'
+		}
+		call_peak_mem_mb: {
+			description: 'Memory (MB) required for task call_peak.',
+			group: 'resource_parameter',
+			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		call_peak_time_hr: {
+			description: 'Walltime (h) required for task call_peak.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		call_peak_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task call_peak.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		macs2_signal_track_mem_mb: {
+			description: 'Memory (MB) required for task macs2_signal_track.',
+			group: 'resource_parameter',
+			help: 'Task macs2_signal_track_mem_mb uses MACS2 to get signal tracks for p-val (suffixed with .pval.) and fold enrichment (suffixed with .fc.). This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		macs2_signal_track_time_hr: {
+			description: 'Walltime (h) required for task macs2_signal_track.',
+			group: 'resource_parameter',
+			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+		}
+		macs2_signal_track_disks: {
+			description: 'Persistent disk size to store intermediate files and outputs of task macs2_signal_track.',
+			group: 'resource_parameter',
+			help: 'This is for GCP/AWS only.'
+		}
+		preseq_mem_mb: {
+			description: 'Memory (MB) required for task preseq.',
+			group: 'resource_parameter',
+			help: 'Task preseq estimates the future yield of a genomic library. This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+		}
+		filter_picard_java_heap: {
+			description: 'Maximum Java heap (java -Xmx) in task filter.',
+			group: 'resource_parameter',
+			help: 'Maximum memory for Picard tools MarkDuplicates. If not defined, 90% of filter_mem_mb will be used.'
+		}
+		preseq_picard_java_heap: {
+			description: 'Maximum Java heap (java -Xmx) in task preseq.',
+			group: 'resource_parameter',
+			help: 'Maximum memory for Picard tools EstimateLibraryComplexity. If not defined, 90% of preseq_mem_mb will be used.'
+		}
+		fraglen_stat_picard_java_heap: {
+			description: 'Maximum Java heap (java -Xmx) in task fraglen_stat_pe (for paired end replicate only).',
+			group: 'resource_parameter',
+			help: 'Maximum memory for Picard tools CollectInsertSizeMetrics. If not defined, 90% of 8000 MB will be used.'
+		}
+		gc_bias_picard_java_heap: {
+			description: 'Maximum Java heap (java -Xmx) in task gc_bias.',
+			group: 'resource_parameter',
+			help: 'Maximum memory for Picard tools CollectGcBiasMetrics. If not defined, 90% of 10000 MB will be used.'
+		}
+	}
+
+	String aligner = 'bowtie2'
 	String peak_caller = 'macs2'
 	String peak_type = 'narrowPeak'
-	File? custom_call_peak_py 		# custom call_peak python script
-
-	# important flags for pipeline
-	Boolean align_only = false		# disable all post-align analyses (peak-calling, overlap, idr, ...)
-	Boolean true_rep_only = false 	# disable all analyses involving pseudo replicates (including overlap/idr)
-	Boolean enable_xcor = false 	# enable cross-corr analysis
-	Boolean enable_count_signal_track = false # generate count signal track
-	Boolean enable_idr = true 		# enable IDR analysis on raw peaks
-	Boolean enable_preseq = false
-	Boolean enable_fraglen_stat = true
-	Boolean enable_tss_enrich = true
-	Boolean enable_annot_enrich = true
-	Boolean enable_jsd = true 		# enable JSD plot generation (deeptools fingerprint)
-	Boolean enable_compare_to_roadmap = false
-	Boolean enable_gc_bias = true
-
-	# parameters for trim_adapter
-	Boolean auto_detect_adapter = false # automatically detect/trim adapters
-	String cutadapt_param = '-e 0.1 -m 5' # cutadapt parameters (err_rate=0.1, min_trim_len=5)
-
-	# parameters for aligner and filter
-	Int multimapping = 4			# for samples with multimapping reads
-	String dup_marker = 'picard'	# picard, sambamba
-	Boolean no_dup_removal = false 	# keep all dups in final BAM
-	Int? mapq_thresh				# threshold for low MAPQ reads removal
-	Int mapq_thresh_bwa = 30
-	Int mapq_thresh_bowtie2 = 30
-	Array[String] filter_chrs = ['chrM', 'MT']
-									# array of chromosomes to be removed from nodup/filt BAM
-									# chromosomes will be removed from both BAM header/contents
-									# e.g. (default: mito-chrs) ['chrM', 'MT']
-	Int subsample_reads = 0			# subsample TAGALIGN (0: no subsampling)
-	Int xcor_subsample_reads = 25000000 # subsample TAG-ALIGN for xcor only (not used for other downsteam analyses)
-
-	# parameters for peak calling
-	Int cap_num_peak = 300000		# cap number of raw peaks for each replicate
-	Float pval_thresh = 0.01		# p.value threshold for peak caller
-	Int smooth_win = 150			# size of smoothing window for peak caller
-	Float idr_thresh = 0.05			# IDR threshold
-
-	# resources
-	#	these variables will be automatically ignored if they are not supported by platform
-	# 	"disks" is for cloud platforms (Google Cloud Platform, DNAnexus) only
-	Int align_cpu = 4
-	Int align_mem_mb = 20000
-	Int align_time_hr = 48
-	String align_disks = 'local-disk 400 HDD'
-
-	Int filter_cpu = 2
-	Int filter_mem_mb = 20000
-	Int filter_time_hr = 24
-	String filter_disks = 'local-disk 400 HDD'
-
-	Int bam2ta_cpu = 2
-	Int bam2ta_mem_mb = 10000
-	Int bam2ta_time_hr = 6
-	String bam2ta_disks = 'local-disk 100 HDD'
-
-	Int spr_mem_mb = 16000
-
-	Int jsd_cpu = 2
-	Int jsd_mem_mb = 12000
-	Int jsd_time_hr = 6
-	String jsd_disks = 'local-disk 200 HDD'
-
-	Int xcor_cpu = 2
-	Int xcor_mem_mb = 16000
-	Int xcor_time_hr = 6
-	String xcor_disks = 'local-disk 100 HDD'
-
-	Int call_peak_cpu = 1
-	Int call_peak_mem_mb = 16000
-	Int call_peak_time_hr = 24
-	String call_peak_disks = 'local-disk 200 HDD'
-
-	Int macs2_signal_track_mem_mb = 16000
-	Int macs2_signal_track_time_hr = 24
-	String macs2_signal_track_disks = 'local-disk 400 HDD'
-
-	Int preseq_mem_mb = 16000
-
-	String? filter_picard_java_heap
-	String? preseq_picard_java_heap
-	String? fraglen_stat_picard_java_heap
-	String? gc_bias_picard_java_heap
-
-	# input file definition
-	# supported types: fastq, bam, nodup_bam (or filtered bam), ta (tagAlign), peak
-	# 	pipeline can start from any type of inputs
-	# 	leave all other types undefined
-	# 	you can define up to 10 replicates
-
- 	# fastqs and adapters  	
-	# 	if auto_detect_adapter == true, undefined adapters will be detected/trimmed 
-	# 	otherwise, only defined adapters will be trimmed
-	# 	so you can selectively detect/trim adapters for a specific fastq
-	Array[File] fastqs_rep1_R1 = []		# FASTQs to be merged for rep1 R1
-	Array[File] fastqs_rep1_R2 = [] 	# do not define if single-ended
-	Array[File] fastqs_rep2_R1 = [] 	# do not define if unreplicated
-	Array[File] fastqs_rep2_R2 = []		# ...
-	Array[File] fastqs_rep3_R1 = []
-	Array[File] fastqs_rep3_R2 = []
-	Array[File] fastqs_rep4_R1 = []
-	Array[File] fastqs_rep4_R2 = []
-	Array[File] fastqs_rep5_R1 = []
-	Array[File] fastqs_rep5_R2 = []
-	Array[File] fastqs_rep6_R1 = []
-	Array[File] fastqs_rep6_R2 = []
-	Array[File] fastqs_rep7_R1 = []
-	Array[File] fastqs_rep7_R2 = []
-	Array[File] fastqs_rep8_R1 = []
-	Array[File] fastqs_rep8_R2 = []
-	Array[File] fastqs_rep9_R1 = []
-	Array[File] fastqs_rep9_R2 = []
-	Array[File] fastqs_rep10_R1 = []
-	Array[File] fastqs_rep10_R2 = []
-
-	String? adapter
-	Array[String] adapters_rep1_R1 = []
-	Array[String] adapters_rep1_R2 = []
-	Array[String] adapters_rep2_R1 = []
-	Array[String] adapters_rep2_R2 = []
-	Array[String] adapters_rep3_R1 = []
-	Array[String] adapters_rep3_R2 = []
-	Array[String] adapters_rep4_R1 = []
-	Array[String] adapters_rep4_R2 = []
-	Array[String] adapters_rep5_R1 = []
-	Array[String] adapters_rep5_R2 = []
-	Array[String] adapters_rep6_R1 = []
-	Array[String] adapters_rep6_R2 = []
-	Array[String] adapters_rep7_R1 = []
-	Array[String] adapters_rep7_R2 = []
-	Array[String] adapters_rep8_R1 = []
-	Array[String] adapters_rep8_R2 = []
-	Array[String] adapters_rep9_R1 = []
-	Array[String] adapters_rep9_R2 = []
-	Array[String] adapters_rep10_R1 = []
-	Array[String] adapters_rep10_R2 = []
-
-	# other input types (bam, nodup_bam, ta). they are per replicate
-	Array[File?] bams = []
-	Array[File?] nodup_bams = []
-	Array[File?] tas = []
-
-	# optional read length array. used it pipeline starts from BAM or TA
-	Array[Int?] read_len = [] 		# [rep_id]. read length for each rep
-
-	# other input types (peak)
-	Array[File?] peaks = []			# per replicate
-	Array[File?] peaks_pr1 = []		# per replicate. do not define if true_rep_only==true
-	Array[File?] peaks_pr2 = []		# per replicate. do not define if true_rep_only==true
-	File? peak_ppr1					# do not define if unreplicated or true_rep_only==true
-	File? peak_ppr2					# do not define if unreplicated or true_rep_only==true
-	File? peak_pooled				# do not define if unreplicated or true_rep_only==true
-
-	####################### pipeline starts here #######################
-	# DO NOT DEFINE ANY VARIABLES DECLARED BELOW IN AN INPUT JSON FILE #
-	# THEY ARE TEMPORARY/INTERMEDIATE SYSTEM VARIABLES                 #
-	####################### pipeline starts here #######################
 	
 	# read genome data and paths
 	if ( defined(genome_tsv) ) {
 		call read_genome_tsv { input: genome_tsv = genome_tsv }
 	}
-	File? ref_fa_ = if defined(ref_fa) then ref_fa
-		else read_genome_tsv.ref_fa
-	File? bwa_idx_tar_ = if defined(bwa_idx_tar) then bwa_idx_tar
-		else read_genome_tsv.bwa_idx_tar
-	File? bwa_mito_idx_tar_ = if defined(bwa_mito_idx_tar) then bwa_mito_idx_tar
-		else read_genome_tsv.bwa_mito_idx_tar
-	File? bowtie2_idx_tar_ = if defined(bowtie2_idx_tar) then bowtie2_idx_tar
-		else read_genome_tsv.bowtie2_idx_tar
-	File? bowtie2_mito_idx_tar_ = if defined(bowtie2_mito_idx_tar) then bowtie2_mito_idx_tar
-		else read_genome_tsv.bowtie2_mito_idx_tar
-	File? custom_aligner_idx_tar_ = if defined(custom_aligner_idx_tar) then custom_aligner_idx_tar
-		else read_genome_tsv.custom_aligner_idx_tar
-	File? custom_aligner_mito_idx_tar_ = if defined(custom_aligner_mito_idx_tar) then custom_aligner_mito_idx_tar
-		else read_genome_tsv.custom_aligner_mito_idx_tar
-	File? chrsz_ = if defined(chrsz) then chrsz
-		else read_genome_tsv.chrsz
-	String? gensz_ = if defined(gensz) then gensz
-		else read_genome_tsv.gensz
+	File ref_fa_ = select_first([ref_fa, read_genome_tsv.ref_fa])
+	File bowtie2_idx_tar_ = select_first([bowtie2_idx_tar, read_genome_tsv.bowtie2_idx_tar])
+	File bowtie2_mito_idx_tar_ = select_first([bowtie2_mito_idx_tar, read_genome_tsv.bowtie2_mito_idx_tar])
+	File chrsz_ = select_first([chrsz, read_genome_tsv.chrsz])
+	String gensz_ = select_first([gensz, read_genome_tsv.gensz])
 	File? blacklist1_ = if defined(blacklist) then blacklist
 		else read_genome_tsv.blacklist
 	File? blacklist2_ = if defined(blacklist2) then blacklist2
@@ -260,13 +849,9 @@ workflow atac {
 	File? blacklist_ = if length(blacklists) > 1 then pool_blacklist.ta_pooled
 		else if length(blacklists) > 0 then blacklists[0]
 		else blacklist2_
-	String? mito_chr_name_ = if defined(mito_chr_name) then mito_chr_name
-		else read_genome_tsv.mito_chr_name
-	String? regex_bfilt_peak_chr_name_ = if defined(regex_bfilt_peak_chr_name) then regex_bfilt_peak_chr_name
-		else read_genome_tsv.regex_bfilt_peak_chr_name
-	String? genome_name_ = if defined(genome_name) then genome_name
-		else if defined(read_genome_tsv.genome_name) then read_genome_tsv.genome_name
-		else basename(select_first([genome_tsv, ref_fa_, chrsz_, 'None']))
+	String mito_chr_name_ = select_first([mito_chr_name, read_genome_tsv.mito_chr_name])
+	String regex_bfilt_peak_chr_name_ = select_first([regex_bfilt_peak_chr_name, read_genome_tsv.regex_bfilt_peak_chr_name])
+	String genome_name_ = select_first([genome_name, read_genome_tsv.genome_name, basename(chrsz_)])
 
 	# read additional annotation data
 	File? tss_ = if defined(tss) then tss
@@ -285,15 +870,14 @@ workflow atac {
 		else read_genome_tsv.roadmap_meta
 
 	### temp vars (do not define these)
-	String aligner_ = if defined(custom_align_py) then 'custom' else aligner
-	String peak_caller_ = if defined(custom_call_peak_py) then 'custom' else peak_caller
+	String aligner_ = aligner
+	String peak_caller_ = peak_caller
 	String peak_type_ = peak_type
 	String idr_rank_ = if peak_caller_=='spp' then 'signal.value'
 						else if peak_caller_=='macs2' then 'p.value'
 						else 'p.value'
 	Int cap_num_peak_ = cap_num_peak
-	Int mapq_thresh_ = if aligner=='bowtie2' then select_first([mapq_thresh, mapq_thresh_bowtie2])
-						else select_first([mapq_thresh, mapq_thresh_bwa])
+	Int mapq_thresh_ = mapq_thresh
 
 	# temporary 2-dim fastqs array [rep_id][merge_id]
 	Array[Array[File]] fastqs_R1 = 
@@ -337,7 +921,7 @@ workflow atac {
 		adapters_rep6_R2, adapters_rep7_R2, adapters_rep8_R2, adapters_rep9_R2, adapters_rep10_R2]
 
 	# temporary variables to get number of replicates
-	# 	WDLic implementation of max(A,B,C,...)
+	#	   WDLic implementation of max(A,B,C,...)
 	Int num_rep_fastq = length(fastqs_R1)
 	Int num_rep_bam = if length(bams)<num_rep_fastq then num_rep_fastq
 		else length(bams)
@@ -355,18 +939,13 @@ workflow atac {
 			msg = 'No FASTQ/BAM/TAG-ALIGN/PEAK defined in your input JSON. Check if your FASTQs are defined as "atac.fastqs_repX_RY". DO NOT MISS suffix _R1 even for single ended FASTQ.'
 		}
 	}
-	if ( !defined(chrsz_) ) {
-		call raise_exception as error_genome_database { input:
-			msg = 'No genome database found in your input JSON. Did you define "atac.genome_tsv" correctly?'
-		}
-	}
 
 	# align each replicate
 	scatter(i in range(num_rep)) {
 		# to override endedness definition for individual replicate
-		# 	paired_end will override paired_ends[i]
-		Boolean? paired_end_ = if !defined(paired_end) && i<length(paired_ends) then paired_ends[i]
-			else paired_end
+		#	 paired_end will override paired_ends[i]
+		Boolean paired_end_ = if !defined(paired_end) && i<length(paired_ends) then paired_ends[i]
+			else select_first([paired_end])
 
 		Boolean has_input_of_align = i<length(fastqs_R1) && length(fastqs_R1[i])>0
 		Boolean has_output_of_align = i<length(bams) && defined(bams[i])
@@ -384,11 +963,8 @@ workflow atac {
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
 				chrsz = chrsz_,
-				custom_align_py = custom_align_py,
 				multimapping = multimapping,
-				idx_tar = if aligner=='bwa' then bwa_idx_tar_
-					else if aligner=='bowtie2' then bowtie2_idx_tar_
-					else custom_aligner_idx_tar_,
+				idx_tar = bowtie2_idx_tar_,
 				# resource
 				cpu = align_cpu,
 				mem_mb = align_mem_mb,
@@ -400,9 +976,7 @@ workflow atac {
 
 		# mito only mapping to get frac mito qc
 		Boolean has_input_of_align_mito = has_input_of_align &&
-			(aligner=='bowtie2' && defined(bowtie2_mito_idx_tar_) ||
-			 aligner=='bwa' && defined(bwa_mito_idx_tar_) ||
-			 defined(custom_aligner_mito_idx_tar_))
+			defined(bowtie2_mito_idx_tar_)
 		if ( has_input_of_align_mito ) {
 			call align as align_mito { input :
 				fastqs_R1 = fastqs_R1[i],
@@ -417,11 +991,8 @@ workflow atac {
 				aligner = aligner_,
 				mito_chr_name = mito_chr_name_,
 				chrsz = chrsz_,
-				custom_align_py = custom_align_py,
 				multimapping = multimapping,
-				idx_tar = if aligner=='bwa' then bwa_mito_idx_tar_
-					else if aligner=='bowtie2' then bowtie2_mito_idx_tar_
-					else custom_aligner_mito_idx_tar_,
+				idx_tar = bowtie2_mito_idx_tar_,
 				# resource
 				cpu = align_cpu,
 				mem_mb = align_mem_mb,
@@ -433,7 +1004,7 @@ workflow atac {
 		if ( defined(align.non_mito_samstat_qc) && defined(align_mito.samstat_qc) ) {
 			call frac_mito { input:
 				non_mito_samstat = align.non_mito_samstat_qc,
-				mito_samstat = align_mito.samstat_qc
+				mito_samstat = align_mito.samstat_qc,
 			}
 		}		
 
@@ -547,7 +1118,6 @@ workflow atac {
 			call call_peak { input :
 				peak_caller = peak_caller_,
 				peak_type = peak_type_,
-				custom_call_peak_py = custom_call_peak_py,
 				ta = ta_,
 				gensz = gensz_,
 				chrsz = chrsz_,
@@ -582,7 +1152,6 @@ workflow atac {
 			call call_peak as call_peak_pr1 { input :
 				peak_caller = peak_caller_,
 				peak_type = peak_type_,
-				custom_call_peak_py = custom_call_peak_py,
 				ta = spr.ta_pr1,
 				gensz = gensz_,
 				chrsz = chrsz_,
@@ -609,7 +1178,6 @@ workflow atac {
 			call call_peak as call_peak_pr2 { input :
 				peak_caller = peak_caller_,
 				peak_type = peak_type_,
-				custom_call_peak_py = custom_call_peak_py,
 				ta = spr.ta_pr2,
 				gensz = gensz_,
 				chrsz = chrsz_,
@@ -729,7 +1297,6 @@ workflow atac {
 		call call_peak as call_peak_pooled { input :
 			peak_caller = peak_caller_,
 			peak_type = peak_type_,
-			custom_call_peak_py = custom_call_peak_py,
 			ta = pool_ta.ta_pooled,
 			gensz = gensz_,
 			chrsz = chrsz_,
@@ -795,7 +1362,6 @@ workflow atac {
 		call call_peak as call_peak_ppr1 { input :
 			peak_caller = peak_caller_,
 			peak_type = peak_type_,
-			custom_call_peak_py = custom_call_peak_py,
 			ta = pool_ta_pr1.ta_pooled,
 			gensz = gensz_,
 			chrsz = chrsz_,
@@ -822,7 +1388,6 @@ workflow atac {
 		call call_peak as call_peak_ppr2 { input :
 			peak_caller = peak_caller_,
 			peak_type = peak_type_,
-			custom_call_peak_py = custom_call_peak_py,
 			ta = pool_ta_pr2.ta_pooled,
 			gensz = gensz_,
 			chrsz = chrsz_,
@@ -842,23 +1407,18 @@ workflow atac {
 		else call_peak_ppr2.peak
 
 	# do IDR/overlap on all pairs of two replicates (i,j)
-	# 	where i and j are zero-based indices and 0 <= i < j < num_rep
-	Array[Pair[Int, Int]] pairs_ = cross(range(num_rep),range(num_rep))
-	scatter( pair in pairs_ ) {
-		Pair[Int, Int]? null_pair
-		Pair[Int, Int]? pairs__ = if pair.left<pair.right then pair else null_pair
-	}
-	Array[Pair[Int, Int]] pairs = select_all(pairs__)
-
-	if ( !align_only ) {
-		scatter( pair in pairs ) {
+	#	where i and j are zero-based indices and 0 <= i < j < num_rep
+	scatter( pair in cross(range(num_rep),range(num_rep)) ) {
+		File? peak1_ = peak_[pair.left]
+		File? peak2_ = peak_[pair.right]
+		if ( !align_only && pair.left<pair.right ) {
 			# pair.left = 0-based index of 1st replicate
 			# pair.right = 0-based index of 2nd replicate
 			# Naive overlap on every pair of true replicates
 			call overlap { input :
 				prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
-				peak1 = peak_[pair.left],
-				peak2 = peak_[pair.right],
+				peak1 = peak1_,
+				peak2 = peak2_,
 				peak_pooled = peak_pooled_,
 				peak_type = peak_type_,
 				blacklist = blacklist_,
@@ -867,17 +1427,14 @@ workflow atac {
 				ta = pool_ta.ta_pooled,
 			}
 		}
-	}
-
-	if ( enable_idr && !align_only ) {
-		scatter( pair in pairs ) {
+		if ( enable_idr && !align_only && pair.left<pair.right ) {
 			# pair.left = 0-based index of 1st replicate
 			# pair.right = 0-based index of 2nd replicate
 			# IDR on every pair of true replicates
 			call idr { input :
 				prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
-				peak1 = peak_[pair.left],
-				peak2 = peak_[pair.right],
+				peak1 = peak1_,
+				peak2 = peak2_,
 				peak_pooled = peak_pooled_,
 				idr_thresh = idr_thresh,
 				peak_type = peak_type_,
@@ -963,7 +1520,7 @@ workflow atac {
 		# reproducibility QC for overlapping peaks
 		call reproducibility as reproducibility_overlap { input :
 			prefix = 'overlap',
-			peaks = overlap.bfilt_overlap_peak,
+			peaks = select_all(overlap.bfilt_overlap_peak),
 			peaks_pr = overlap_pr.bfilt_overlap_peak,
 			peak_ppr = overlap_ppr.bfilt_overlap_peak,
 			peak_type = peak_type_,
@@ -975,7 +1532,7 @@ workflow atac {
 		# reproducibility QC for IDR peaks
 		call reproducibility as reproducibility_idr { input :
 			prefix = 'idr',
-			peaks = idr.bfilt_idr_peak,
+			peaks = select_all(idr.bfilt_idr_peak),
 			peaks_pr = idr_pr.bfilt_idr_peak,
 			peak_ppr = idr_ppr.bfilt_idr_peak,
 			peak_type = peak_type_,
@@ -999,51 +1556,51 @@ workflow atac {
 		pval_thresh = pval_thresh,
 		xcor_subsample_reads = xcor_subsample_reads,
 
-		samstat_qcs = align.samstat_qc,
-		nodup_samstat_qcs = filter.samstat_qc,
+		samstat_qcs = select_all(align.samstat_qc),
+		nodup_samstat_qcs = select_all(filter.samstat_qc),
 
-		frac_mito_qcs = frac_mito.frac_mito_qc,
-		dup_qcs = filter.dup_qc,
-		lib_complexity_qcs = filter.lib_complexity_qc,
-		xcor_plots = xcor.plot_png,
-		xcor_scores = xcor.score,
+		frac_mito_qcs = select_all(frac_mito.frac_mito_qc),
+		dup_qcs = select_all(filter.dup_qc),
+		lib_complexity_qcs = select_all(filter.lib_complexity_qc),
+		xcor_plots = select_all(xcor.plot_png),
+		xcor_scores = select_all(xcor.score),
 
 		jsd_plot = jsd.plot,
 		jsd_qcs = jsd.jsd_qcs,
 
-		frip_qcs = call_peak.frip_qc,
-		frip_qcs_pr1 = call_peak_pr1.frip_qc,
-		frip_qcs_pr2 = call_peak_pr2.frip_qc,
+		frip_qcs = select_all(call_peak.frip_qc),
+		frip_qcs_pr1 = select_all(call_peak_pr1.frip_qc),
+		frip_qcs_pr2 = select_all(call_peak_pr2.frip_qc),
 
 		frip_qc_pooled = call_peak_pooled.frip_qc,
 		frip_qc_ppr1 = call_peak_ppr1.frip_qc,
 		frip_qc_ppr2 = call_peak_ppr2.frip_qc,
 
-		idr_plots = idr.idr_plot,
+		idr_plots = select_all(idr.idr_plot),
 		idr_plots_pr = idr_pr.idr_plot,
 		idr_plot_ppr = idr_ppr.idr_plot,
-		frip_idr_qcs = idr.frip_qc,
+		frip_idr_qcs = select_all(idr.frip_qc),
 		frip_idr_qcs_pr = idr_pr.frip_qc,
 		frip_idr_qc_ppr = idr_ppr.frip_qc,
-		frip_overlap_qcs = overlap.frip_qc,
+		frip_overlap_qcs = select_all(overlap.frip_qc),
 		frip_overlap_qcs_pr = overlap_pr.frip_qc,
 		frip_overlap_qc_ppr = overlap_ppr.frip_qc,
 		idr_reproducibility_qc = reproducibility_idr.reproducibility_qc,
 		overlap_reproducibility_qc = reproducibility_overlap.reproducibility_qc,
 
-		annot_enrich_qcs = annot_enrich.annot_enrich_qc,
-		tss_enrich_qcs = tss_enrich.tss_enrich_qc,
-		tss_large_plots = tss_enrich.tss_large_plot,
-		roadmap_compare_plots = compare_signal_to_roadmap.roadmap_compare_plot,
-		fraglen_dist_plots = fraglen_stat_pe.fraglen_dist_plot,
-		fraglen_nucleosomal_qcs = fraglen_stat_pe.nucleosomal_qc,
-		gc_plots = gc_bias.gc_plot,
-		preseq_plots = preseq.preseq_plot,
-		picard_est_lib_size_qcs = preseq.picard_est_lib_size_qc,
+		annot_enrich_qcs = select_all(annot_enrich.annot_enrich_qc),
+		tss_enrich_qcs = select_all(tss_enrich.tss_enrich_qc),
+		tss_large_plots = select_all(tss_enrich.tss_large_plot),
+		roadmap_compare_plots = select_all(compare_signal_to_roadmap.roadmap_compare_plot),
+		fraglen_dist_plots = select_all(fraglen_stat_pe.fraglen_dist_plot),
+		fraglen_nucleosomal_qcs = select_all(fraglen_stat_pe.nucleosomal_qc),
+		gc_plots = select_all(gc_bias.gc_plot),
+		preseq_plots = select_all(preseq.preseq_plot),
+		picard_est_lib_size_qcs = select_all(preseq.picard_est_lib_size_qc),
 
-		peak_region_size_qcs = call_peak.peak_region_size_qc,
-		peak_region_size_plots = call_peak.peak_region_size_plot,
-		num_peak_qcs = call_peak.num_peak_qc,
+		peak_region_size_qcs = select_all(call_peak.peak_region_size_qc),
+		peak_region_size_plots = select_all(call_peak.peak_region_size_plot),
+		num_peak_qcs = select_all(call_peak.num_peak_qc),
 
 		idr_opt_peak_region_size_qc = reproducibility_idr.peak_region_size_qc,
 		idr_opt_peak_region_size_plot = reproducibility_overlap.peak_region_size_plot,
@@ -1062,31 +1619,32 @@ workflow atac {
 }
 
 task align {
-	# for task trim_adapter
-	Array[File] fastqs_R1 		# [merge_id]
-	Array[File] fastqs_R2
+	input {
+		# for task trim_adapter
+		Array[File] fastqs_R1		 # [merge_id]
+		Array[File] fastqs_R2
 
-	String? adapter 	# adapter for all fastqs,
-						#	this will override individual adapters in adapters_R1/R2
-	Array[String] adapters_R1
-	Array[String] adapters_R2
-	Boolean paired_end
-	Boolean auto_detect_adapter
-	String cutadapt_param 
+		String? adapter	 # adapter for all fastqs,
+							#	this will override individual adapters in adapters_R1/R2
+		Array[String] adapters_R1
+		Array[String] adapters_R2
+		Boolean paired_end
+		Boolean auto_detect_adapter
+		String cutadapt_param
 
-	# for task align
-	String aligner
-	String mito_chr_name
-	File chrsz			# 2-col chromosome sizes file
-	File? custom_align_py
-	File idx_tar		# reference index tar or tar.gz
-	Int multimapping
+		# for task align
+		String aligner
+		String mito_chr_name
+		File chrsz			# 2-col chromosome sizes file
+		File idx_tar		# reference index tar or tar.gz
+		Int multimapping
 
-	# resource
-	Int cpu
-	Int mem_mb
-	Int time_hr
-	String disks
+		# resource
+		Int cpu
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 
 	# tmp vars for task trim_adapter
 	Array[Array[File]] tmp_fastqs = if paired_end then transpose([fastqs_R1, fastqs_R2])
@@ -1101,7 +1659,7 @@ task align {
 		then
 		  echo -e "\n* Error: pipeline dependencies not found." 1>&2
 		  echo 'Conda users: Did you activate Conda environment (conda activate encode-atac-seq-pipeline)?' 1>&2
-		  echo '    Or did you install Conda and environment correctly (bash scripts/install_conda_env.sh)?' 1>&2
+		  echo '	Or did you install Conda and environment correctly (bash scripts/install_conda_env.sh)?' 1>&2
 		  echo 'GCP/AWS/Docker users: Did you add --docker flag to Caper command line arg?' 1>&2
 		  echo 'Singularity users: Did you add --singularity flag to Caper command line arg?' 1>&2
 		  echo -e "\n" 1>&2
@@ -1121,14 +1679,6 @@ task align {
 		# align on trimmed/merged fastqs
 		if [ '${aligner}' == 'bowtie2' ]; then
 			python3 $(which encode_task_bowtie2.py) \
-				${idx_tar} \
-				R1/*.fastq.gz \
-				${if paired_end then 'R2/*.fastq.gz' else ''} \
-				${if paired_end then '--paired-end' else ''} \
-				${'--multimapping ' + multimapping} \
-				${'--nth ' + cpu}
-		else
-			python3 ${custom_align_py} \
 				${idx_tar} \
 				R1/*.fastq.gz \
 				${if paired_end then 'R2/*.fastq.gz' else ''} \
@@ -1162,8 +1712,10 @@ task align {
 }
 
 task frac_mito {
-	File non_mito_samstat
-	File mito_samstat
+	input {
+		File? non_mito_samstat
+		File? mito_samstat
+	}
 
 	command {
 		python3 $(which encode_task_frac_mito.py) \
@@ -1181,23 +1733,25 @@ task frac_mito {
 }
 
 task filter {
-	File bam
-	Boolean paired_end
-	Int multimapping
-	String dup_marker 			# picard.jar MarkDuplicates (picard) or 
-								# sambamba markdup (sambamba)
-	Int mapq_thresh				# threshold for low MAPQ reads removal
-	Array[String] filter_chrs 	# chrs to be removed from final (nodup/filt) BAM
-	File chrsz					# 2-col chromosome sizes file
-	Boolean no_dup_removal 		# no dupe reads removal when filtering BAM
-	String mito_chr_name
+	input {
+		File? bam
+		Boolean paired_end
+		Int multimapping
+		String dup_marker			 # picard.jar MarkDuplicates (picard) or 
+									# sambamba markdup (sambamba)
+		Int mapq_thresh				# threshold for low MAPQ reads removal
+		Array[String] filter_chrs	 # chrs to be removed from final (nodup/filt) BAM
+		File chrsz					# 2-col chromosome sizes file
+		Boolean no_dup_removal		 # no dupe reads removal when filtering BAM
+		String mito_chr_name
 
-	Int cpu
-	Int mem_mb
+		Int cpu
+		Int mem_mb
+		String? picard_java_heap
+		Int time_hr
+		String disks
+	}
 	Float picard_java_heap_factor = 0.9
-	String? picard_java_heap
-	Int time_hr
-	String disks
 
 	command {
 		python3 $(which encode_task_filter.py) \
@@ -1229,16 +1783,18 @@ task filter {
 }
 
 task bam2ta {
-	File bam
-	Boolean paired_end
-	Boolean disable_tn5_shift 	# no tn5 shifting (it's for dnase-seq)
-	String mito_chr_name 		# mito chromosome name
-	Int subsample 				# number of reads to subsample TAGALIGN
-								# this affects all downstream analysis
-	Int cpu
-	Int mem_mb
-	Int time_hr
-	String disks
+	input {
+		File? bam
+		Boolean paired_end
+		Boolean disable_tn5_shift	 # no tn5 shifting (it's for dnase-seq)
+		String mito_chr_name		 # mito chromosome name
+		Int subsample				 # number of reads to subsample TAGALIGN
+									# this affects all downstream analysis
+		Int cpu
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 
 	command {
 		python3 $(which encode_task_bam2ta.py) \
@@ -1260,11 +1816,14 @@ task bam2ta {
 	}
 }
 
-task spr { # make two self pseudo replicates
-	File ta
-	Boolean paired_end
+task spr {
+	# make two self pseudo replicates
+	input {
+		File? ta
+		Boolean paired_end
 
-	Int mem_mb
+		Int mem_mb
+	}
 
 	command {
 		python3 $(which encode_task_spr.py) \
@@ -1284,13 +1843,14 @@ task spr { # make two self pseudo replicates
 }
 
 task pool_ta {
-	Array[File?] tas 	# TAG-ALIGNs to be merged
-	Int? col 			# number of columns in pooled TA
-	String? prefix 		# basename prefix
-
+	input {
+		Array[File?] tas	 # TAG-ALIGNs to be merged
+		Int? col			 # number of columns in pooled TA
+		String? prefix		 # basename prefix
+	}
 	command {
 		python3 $(which encode_task_pool_ta.py) \
-			${sep=' ' tas} \
+			${sep=' ' select_all(tas)} \
 			${'--prefix ' + prefix} \
 			${'--col ' + col}
 	}
@@ -1306,16 +1866,18 @@ task pool_ta {
 }
 
 task xcor {
-	File ta
-	Boolean paired_end
-	String mito_chr_name
-	Int subsample  # number of reads to subsample TAGALIGN
-				# this will be used for xcor only
-				# will not affect any downstream analysis
-	Int cpu
-	Int mem_mb	
-	Int time_hr
-	String disks
+	input {
+		File? ta
+		Boolean paired_end
+		String mito_chr_name
+		Int subsample  # number of reads to subsample TAGALIGN
+					# this will be used for xcor only
+					# will not affect any downstream analysis
+		Int cpu
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 
 	command {
 		python3 $(which encode_task_xcor.py) \
@@ -1330,7 +1892,6 @@ task xcor {
 		File plot_pdf = glob('*.cc.plot.pdf')[0]
 		File plot_png = glob('*.cc.plot.png')[0]
 		File score = glob('*.cc.qc')[0]
-		Int fraglen = read_int(glob('*.cc.fraglen.txt')[0])
 	}
 	runtime {
 		cpu : cpu
@@ -1341,18 +1902,20 @@ task xcor {
 }
 
 task jsd {
-	Array[File?] nodup_bams
-	File blacklist
-	Int mapq_thresh
+	input {
+		Array[File?] nodup_bams
+		File? blacklist
+		Int mapq_thresh
 
-	Int cpu
-	Int mem_mb
-	Int time_hr
-	String disks
+		Int cpu
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 
 	command {
 		python3 $(which encode_task_jsd.py) \
-			${sep=' ' nodup_bams} \
+			${sep=' ' select_all(nodup_bams)} \
 			${'--mapq-thresh '+ mapq_thresh} \
 			${'--blacklist '+ blacklist} \
 			${'--nth ' + cpu}
@@ -1370,9 +1933,10 @@ task jsd {
 }
 
 task count_signal_track {
-	File ta 			# tag-align
-	File chrsz			# 2-col chromosome sizes file
-
+	input {
+		File? ta			 # tag-align
+		File chrsz			# 2-col chromosome sizes file
+	}
 	command {
 		python3 $(which encode_task_count_signal_track.py) \
 			${ta} \
@@ -1391,38 +1955,30 @@ task count_signal_track {
 }
 
 task call_peak {
-	String peak_caller
-	String peak_type
-	File? custom_call_peak_py
+	input {
+		String peak_caller
+		String peak_type
 
-	File ta
-	String gensz		# Genome size (sum of entries in 2nd column of 
-                        # chr. sizes file, or hs for human, ms for mouse)
-	File chrsz			# 2-col chromosome sizes file
-	Int cap_num_peak	# cap number of raw peaks called from MACS2
-	Float pval_thresh  	# p.value threshold
-	Int smooth_win 		# size of smoothing window
-	File? blacklist 	# blacklist BED to filter raw peaks
-	String? regex_bfilt_peak_chr_name
+		File? ta
+		String gensz		# Genome size (sum of entries in 2nd column of 
+							# chr. sizes file, or hs for human, ms for mouse)
+		File chrsz			# 2-col chromosome sizes file
+		Int cap_num_peak	# cap number of raw peaks called from MACS2
+		Float pval_thresh	  # p.value threshold
+		Int smooth_win		 # size of smoothing window
+		File? blacklist	 # blacklist BED to filter raw peaks
+		String? regex_bfilt_peak_chr_name
 
-	Int cpu
-	Int mem_mb
-	Int time_hr
-	String disks
-
+		Int cpu
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 	command {
 		set -e
 
 		if [ '${peak_caller}' == 'macs2' ]; then
 			python3 $(which encode_task_macs2_atac.py) \
-				${ta} \
-				${'--gensz ' + gensz} \
-				${'--chrsz ' + chrsz} \
-				${'--cap-num-peak ' + cap_num_peak} \
-				${'--pval-thresh '+ pval_thresh} \
-				${'--smooth-win '+ smooth_win}
-		else
-			python ${custom_call_peak_py} \
 				${ta} \
 				${'--gensz ' + gensz} \
 				${'--chrsz ' + chrsz} \
@@ -1440,7 +1996,6 @@ task call_peak {
 			${'--blacklist ' + blacklist}
 	}
 	output {
-		# generated by custom_call_peak_py
 		File peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
 		# generated by post_call_peak py
 		File bfilt_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
@@ -1462,17 +2017,18 @@ task call_peak {
 }
 
 task macs2_signal_track {
-	File ta
-	String gensz		# Genome size (sum of entries in 2nd column of 
-                        # chr. sizes file, or hs for human, ms for mouse)
-	File chrsz			# 2-col chromosome sizes file
-	Float pval_thresh  	# p.value threshold
-	Int smooth_win 		# size of smoothing window
-	
-	Int mem_mb
-	Int time_hr
-	String disks
+	input {
+		File? ta
+		String gensz		# Genome size (sum of entries in 2nd column of 
+							# chr. sizes file, or hs for human, ms for mouse)
+		File chrsz			# 2-col chromosome sizes file
+		Float pval_thresh	  # p.value threshold
+		Int smooth_win		 # size of smoothing window
 
+		Int mem_mb
+		Int time_hr
+		String disks
+	}
 	command {
 		python3 $(which encode_task_macs2_signal_track_atac.py) \
 			${ta} \
@@ -1495,19 +2051,20 @@ task macs2_signal_track {
 }
 
 task idr {
-	String prefix 		# prefix for IDR output file
-	File peak1 			
-	File peak2
-	File peak_pooled
-	Float idr_thresh
-	File? blacklist 	# blacklist BED to filter raw peaks
-	String regex_bfilt_peak_chr_name
-	# parameters to compute FRiP
-	File? ta			# to calculate FRiP
-	File chrsz			# 2-col chromosome sizes file
-	String peak_type
-	String rank
-
+	input {
+		String prefix		 # prefix for IDR output file
+		File? peak1
+		File? peak2
+		File? peak_pooled
+		Float idr_thresh
+		File? blacklist	 # blacklist BED to filter raw peaks
+		String regex_bfilt_peak_chr_name
+		# parameters to compute FRiP
+		File? ta			# to calculate FRiP
+		File chrsz			# 2-col chromosome sizes file
+		String peak_type
+		String rank
+	}
 	command {
 		${if defined(ta) then '' else 'touch null.frip.qc'}
 		touch null
@@ -1542,16 +2099,17 @@ task idr {
 }
 
 task overlap {
-	String prefix 		# prefix for IDR output file
-	File peak1
-	File peak2
-	File peak_pooled
-	File? blacklist 	# blacklist BED to filter raw peaks
-	String regex_bfilt_peak_chr_name
-	File? ta		# to calculate FRiP
-	File chrsz			# 2-col chromosome sizes file
-	String peak_type
-
+	input {
+		String prefix		 # prefix for IDR output file
+		File? peak1
+		File? peak2
+		File? peak_pooled
+		File? blacklist	 # blacklist BED to filter raw peaks
+		String regex_bfilt_peak_chr_name
+		File? ta		# to calculate FRiP
+		File chrsz			# 2-col chromosome sizes file
+		String peak_type
+	}
 	command {
 		${if defined(ta) then '' else 'touch null.frip.qc'}
 		touch null 
@@ -1582,16 +2140,17 @@ task overlap {
 }
 
 task reproducibility {
-	String prefix
-	Array[File]? peaks # peak files from pair of true replicates
-						# in a sorted order. for example of 4 replicates,
-						# 1,2 1,3 1,4 2,3 2,4 3,4.
-                        # x,y means peak file from rep-x vs rep-y
-	Array[File?] peaks_pr	# peak files from pseudo replicates
-	File? peak_ppr			# Peak file from pooled pseudo replicate.
-	String peak_type
-	File chrsz			# 2-col chromosome sizes file
-
+	input {
+		String prefix
+		Array[File] peaks # peak files from pair of true replicates
+							# in a sorted order. for example of 4 replicates,
+							# 1,2 1,3 1,4 2,3 2,4 3,4.
+							# x,y means peak file from rep-x vs rep-y
+		Array[File]? peaks_pr	# peak files from pseudo replicates
+		File? peak_ppr			# Peak file from pooled pseudo replicate.
+		String peak_type
+		File chrsz			# 2-col chromosome sizes file
+	}
 	command {
 		python3 $(which encode_task_reproducibility.py) \
 			${sep=' ' peaks} \
@@ -1625,23 +2184,26 @@ task reproducibility {
 }
 
 task preseq {
-	File bam
-	Boolean paired_end
+	input {
+		File? bam
+		Boolean paired_end
 
-	Int mem_mb
+		Int mem_mb
+		String? picard_java_heap
+		File? null
+	}
 	Float picard_java_heap_factor = 0.9
-	String? picard_java_heap
 
-	File? null_f
 	command {
 		python3 $(which encode_task_preseq.py) \
 			${if paired_end then '--paired-end' else ''} \
 			${'--bam ' + bam} \
 			${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
+		${if !paired_end then 'touch null.picard_est_lib_size' else ''}
 	}
 	output {
 		File? picard_est_lib_size_qc = if paired_end then 
-			glob('*.picard_est_lib_size.qc')[0] else null_f
+			glob('*.picard_est_lib_size.qc')[0] else null
 		File preseq_plot = glob('*.preseq.png')[0]
 		File preseq_log = glob('*.preseq.log')[0]
 	}
@@ -1654,13 +2216,14 @@ task preseq {
 }
 
 task annot_enrich {
-	# Fraction of Reads In Annotated Regions
-	File ta
-	File? blacklist
-	File? dnase
-	File? prom
-	File? enh
-
+	input {
+		# Fraction of Reads In Annotated Regions
+		File? ta
+		File? blacklist
+		File? dnase
+		File? prom
+		File? enh
+	}
 	command {
 		python3 $(which encode_task_annot_enrich.py) \
 			${'--ta ' + ta} \
@@ -1681,11 +2244,12 @@ task annot_enrich {
 }
 
 task tss_enrich {
-	Int? read_len
-	File nodup_bam
-	File tss
-	File chrsz
-
+	input {
+		Int? read_len
+		File? nodup_bam
+		File? tss
+		File chrsz
+	}
 	command {
 		python2 $(which encode_task_tss_enrich.py) \
 			${'--read-len ' + read_len} \
@@ -1709,11 +2273,12 @@ task tss_enrich {
 
 task fraglen_stat_pe {
 	# for PE only
-	File nodup_bam
-
+	input {
+		File? nodup_bam
+		String? picard_java_heap
+	}
 	Int mem_mb = 8000
 	Float picard_java_heap_factor = 0.9
-	String? picard_java_heap
 
 	command {
 		python3 $(which encode_task_fraglen_stat_pe.py) \
@@ -1733,12 +2298,14 @@ task fraglen_stat_pe {
 }
 
 task gc_bias {
-	File nodup_bam
-	File ref_fa
+	input {
+		File? nodup_bam
+		File ref_fa
 
+		String? picard_java_heap
+	}
 	Int mem_mb = 10000
 	Float picard_java_heap_factor = 0.9
-	String? picard_java_heap
 
 	command {
 		python3 $(which encode_task_gc_bias.py) \
@@ -1759,12 +2326,13 @@ task gc_bias {
 }
 
 task compare_signal_to_roadmap {
-	File pval_bw
-	File? dnase
-	File? reg2map_bed
-	File reg2map
-	File roadmap_meta
-
+	input {
+		File? pval_bw
+		File? dnase
+		File? reg2map_bed
+		File? reg2map
+		File? roadmap_meta
+	}
 	command {
 		python3 $(which encode_task_compare_signal_to_roadmap.py) \
 			${'--bigwig ' + pval_bw} \
@@ -1789,72 +2357,73 @@ task compare_signal_to_roadmap {
 # - qc.html		: organized final HTML report
 # - qc.json		: all QCs
 task qc_report {
-	String pipeline_ver
- 	String title
-	String description
-	String? genome	
-	# workflow params
-	Int multimapping
-	Array[Boolean?] paired_ends
-	String pipeline_type
-	String aligner
-	String peak_caller
-	Int cap_num_peak
-	Float idr_thresh
-	Float pval_thresh
-	Int xcor_subsample_reads
-	# QCs
-	Array[File?] frac_mito_qcs
-	Array[File?] samstat_qcs
-	Array[File?] nodup_samstat_qcs
-	Array[File?] dup_qcs
-	Array[File?] lib_complexity_qcs
-	Array[File?] xcor_plots
-	Array[File?] xcor_scores
-	File? jsd_plot
-	Array[File]? jsd_qcs	
-	Array[File]? idr_plots
-	Array[File]? idr_plots_pr
-	File? idr_plot_ppr
-	Array[File?] frip_qcs
-	Array[File?] frip_qcs_pr1
-	Array[File?] frip_qcs_pr2
-	File? frip_qc_pooled
-	File? frip_qc_ppr1 
-	File? frip_qc_ppr2 
-	Array[File]? frip_idr_qcs
-	Array[File]? frip_idr_qcs_pr
-	File? frip_idr_qc_ppr 
-	Array[File]? frip_overlap_qcs
-	Array[File]? frip_overlap_qcs_pr
-	File? frip_overlap_qc_ppr
-	File? idr_reproducibility_qc
-	File? overlap_reproducibility_qc
+	input {
+		String pipeline_ver
+		String title
+		String description
+		String? genome
+		# workflow params
+		Int multimapping
+		Array[Boolean] paired_ends
+		String pipeline_type
+		String aligner
+		String peak_caller
+		Int cap_num_peak
+		Float idr_thresh
+		Float pval_thresh
+		Int xcor_subsample_reads
+		# QCs
+		Array[File] frac_mito_qcs
+		Array[File] samstat_qcs
+		Array[File] nodup_samstat_qcs
+		Array[File] dup_qcs
+		Array[File] lib_complexity_qcs
+		Array[File] xcor_plots
+		Array[File] xcor_scores
+		File? jsd_plot
+		Array[File]? jsd_qcs
+		Array[File] idr_plots
+		Array[File]? idr_plots_pr
+		File? idr_plot_ppr
+		Array[File] frip_qcs
+		Array[File] frip_qcs_pr1
+		Array[File] frip_qcs_pr2
+		File? frip_qc_pooled
+		File? frip_qc_ppr1
+		File? frip_qc_ppr2
+		Array[File] frip_idr_qcs
+		Array[File]? frip_idr_qcs_pr
+		File? frip_idr_qc_ppr
+		Array[File] frip_overlap_qcs
+		Array[File]? frip_overlap_qcs_pr
+		File? frip_overlap_qc_ppr
+		File? idr_reproducibility_qc
+		File? overlap_reproducibility_qc
 
-	Array[File?] annot_enrich_qcs
-	Array[File?] tss_enrich_qcs
-	Array[File?] tss_large_plots
-	Array[File?] roadmap_compare_plots
-	Array[File?] fraglen_dist_plots
-	Array[File?] fraglen_nucleosomal_qcs
-	Array[File?] gc_plots
-	Array[File?] preseq_plots
-	Array[File?] picard_est_lib_size_qcs
+		Array[File] annot_enrich_qcs
+		Array[File] tss_enrich_qcs
+		Array[File] tss_large_plots
+		Array[File] roadmap_compare_plots
+		Array[File] fraglen_dist_plots
+		Array[File] fraglen_nucleosomal_qcs
+		Array[File] gc_plots
+		Array[File] preseq_plots
+		Array[File] picard_est_lib_size_qcs
 
-	Array[File?] peak_region_size_qcs
-	Array[File?] peak_region_size_plots
-	Array[File?] num_peak_qcs
+		Array[File] peak_region_size_qcs
+		Array[File] peak_region_size_plots
+		Array[File] num_peak_qcs
 
-	File? idr_opt_peak_region_size_qc
-	File? idr_opt_peak_region_size_plot
-	File? idr_opt_num_peak_qc
+		File? idr_opt_peak_region_size_qc
+		File? idr_opt_peak_region_size_plot
+		File? idr_opt_num_peak_qc
 
-	File? overlap_opt_peak_region_size_qc
-	File? overlap_opt_peak_region_size_plot
-	File? overlap_opt_num_peak_qc
+		File? overlap_opt_peak_region_size_qc
+		File? overlap_opt_peak_region_size_plot
+		File? overlap_opt_num_peak_qc
 
-	File? qc_json_ref
-
+		File? qc_json_ref
+	}
 	command {
 		python3 $(which encode_task_qc_report.py) \
 			${'--pipeline-ver ' + pipeline_ver} \
@@ -1932,16 +2501,16 @@ task qc_report {
 }
 
 task read_genome_tsv {
-	File genome_tsv
-
-	String? null_s
+	input {
+		File? genome_tsv
+		String? null_s
+	}
 	command <<<
+		echo "$(basename ~{genome_tsv})" > genome_name
 		# create empty files for all entries
-		touch genome_name
-		touch ref_fa bowtie2_idx_tar bwa_idx_tar chrsz gensz blacklist blacklist2
-		touch custom_aligner_idx_tar
+		touch ref_fa bowtie2_idx_tar chrsz gensz blacklist blacklist2
 		touch ref_mito_fa
-		touch bowtie2_mito_idx_tar bwa_mito_idx_tar custom_aligner_mito_idx_tar
+		touch bowtie2_mito_idx_tar
 		touch tss tss_enrich # for backward compatibility
 		touch dnase prom enh reg2map reg2map_bed roadmap_meta
 		touch mito_chr_name
@@ -1949,7 +2518,7 @@ task read_genome_tsv {
 
 		python <<CODE
 		import os
-		with open('${genome_tsv}','r') as fp:
+		with open('~{genome_tsv}','r') as fp:
 			for line in fp:
 				arr = line.strip('\n').split('\t')
 				if arr:
@@ -1959,15 +2528,11 @@ task read_genome_tsv {
 		CODE
 	>>>
 	output {
-		String? genome_name = if size('genome_name')==0 then basename(genome_tsv) else read_string('genome_name')
+		String? genome_name = read_string('genome_name')
 		String? ref_fa = if size('ref_fa')==0 then null_s else read_string('ref_fa')
 		String? ref_mito_fa = if size('ref_mito_fa')==0 then null_s else read_string('ref_mito_fa')
-		String? bwa_idx_tar = if size('bwa_idx_tar')==0 then null_s else read_string('bwa_idx_tar')
-		String? bwa_mito_idx_tar = if size('bwa_mito_idx_tar')==0 then null_s else read_string('bwa_mito_idx_tar')
 		String? bowtie2_idx_tar = if size('bowtie2_idx_tar')==0 then null_s else read_string('bowtie2_idx_tar')
 		String? bowtie2_mito_idx_tar = if size('bowtie2_mito_idx_tar')==0 then null_s else read_string('bowtie2_mito_idx_tar')
-		String? custom_aligner_idx_tar = if size('custom_aligner_idx_tar')==0 then null_s else read_string('custom_aligner_idx_tar')
-		String? custom_aligner_mito_idx_tar = if size('custom_aligner_mito_idx_tar')==0 then null_s else read_string('custom_aligner_mito_idx_tar')
 		String? chrsz = if size('chrsz')==0 then null_s else read_string('chrsz')
 		String? gensz = if size('gensz')==0 then null_s else read_string('gensz')
 		String? blacklist = if size('blacklist')==0 then null_s else read_string('blacklist')
@@ -1975,7 +2540,6 @@ task read_genome_tsv {
 		String? mito_chr_name = if size('mito_chr_name')==0 then null_s else read_string('mito_chr_name')
 		String? regex_bfilt_peak_chr_name = if size('regex_bfilt_peak_chr_name')==0 then 'chr[\\dXY]+'
 			else read_string('regex_bfilt_peak_chr_name')
-		# optional data
 		String? tss = if size('tss')!=0 then read_string('tss')
 			else if size('tss_enrich')!=0 then read_string('tss_enrich') else null_s
 		String? dnase = if size('dnase')==0 then null_s else read_string('dnase')
@@ -1995,7 +2559,9 @@ task read_genome_tsv {
 }
 
 task raise_exception {
-	String msg
+	input {
+		String msg
+	}
 	command {
 		echo -e "\n* Error: ${msg}\n" >&2
 		exit 2

--- a/atac.wdl
+++ b/atac.wdl
@@ -1820,7 +1820,6 @@ task bam2ta {
 }
 
 task spr {
-    # make two self pseudo replicates
     input {
         File? ta
         Boolean paired_end
@@ -2369,9 +2368,6 @@ task compare_signal_to_roadmap {
     }
 }
 
-# gather all outputs and generate 
-# - qc.html        : organized final HTML report
-# - qc.json        : all QCs
 task qc_report {
     input {
         String pipeline_ver

--- a/atac.wdl
+++ b/atac.wdl
@@ -1,15 +1,15 @@
 version 1.0
 
 workflow atac {
-    String pipeline_ver = 'v1.7.1'
+    String pipeline_ver = 'dev-v1.7.2'
 
     meta {
         author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
         description: 'ATAC-Seq/DNase-Seq pipeline'
         specification_document: 'https://docs.google.com/document/d/1f0Cm4vRyDQDu0bMehHD7P7KOMxTOP-HiNoIvL1VcBt8/edit?usp=sharing'
 
-        caper_docker: 'quay.io/encode-dcc/atac-seq-pipeline:v1.7.1'
-        caper_singularity: 'docker://quay.io/encode-dcc/atac-seq-pipeline:v1.7.1'
+        caper_docker: 'quay.io/encode-dcc/atac-seq-pipeline:dev-v1.7.2'
+        caper_singularity: 'docker://quay.io/encode-dcc/atac-seq-pipeline:dev-v1.7.2'
         croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/atac.croo.v4.json'
     }
     input {

--- a/atac.wdl
+++ b/atac.wdl
@@ -410,12 +410,12 @@ workflow atac {
         peak_ppr1: {
             description: 'NARROWPEAK file for pooled pseudo replicate 1.',
             group: 'input_genomic_data',
-            help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and atac.truerep_only flag is off. PPR1 means analysis on pooled 1st pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 1st pseudos.'
+            help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and atac.true_rep_only flag is off. PPR1 means analysis on pooled 1st pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 1st pseudos.'
         }
         peak_ppr2: {
             description: 'NARROWPEAK file for pooled pseudo replicate 2.',
             group: 'input_genomic_data',
-            help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and atac.truerep_only flag is off. PPR1 means analysis on pooled 2nd pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 2nd pseudos.'
+            help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and atac.true_rep_only flag is off. PPR1 means analysis on pooled 2nd pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 2nd pseudos.'
         }
 
         pipeline_type: {
@@ -619,12 +619,12 @@ workflow atac {
         subsample_reads: {
             description: 'Subsample reads. Shuffle and subsample reads.',
             group: 'alignment',
-            help: 'This affects all downstream analyses after filtering BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number.'
+            help: 'This affects all downstream analyses after filtering BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number.  0 means disabled.'
         }
         xcor_subsample_reads: {
             description: 'Subsample reads for cross-corrlelation analysis only.',
             group: 'alignment',
-            help: 'This does not affect downstream analyses after filtering BAM. It is for cross-correlation analysis only.'
+            help: 'This does not affect downstream analyses after filtering BAM. It is for cross-correlation analysis only. 0 means disabled.'
         }
         read_len: {
             description: 'Read length per biological replicate.',

--- a/atac.wdl
+++ b/atac.wdl
@@ -175,11 +175,11 @@ workflow atac {
     parameter_meta {
         title: {
             description: 'Experiment title.',
-            group: 'pipeline_metadata',
+            group: 'pipeline_metadata'
         }
         description: {
             description: 'Experiment description.',
-            group: 'pipeline_metadata',
+            group: 'pipeline_metadata'
         }
         genome_tsv: {
             description: 'Reference genome database TSV.',
@@ -275,9 +275,9 @@ workflow atac {
         fastqs_rep1_R1: {
             description: 'Read1 FASTQs to be merged for a biological replicate 1.',
             group: 'input_genomic_data',
-            help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of inputs (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined. Especially for FASTQs, we have individual variable for each biological replicate to allow FASTQs of technical replicates can be merged. Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep1_R2). These FASTQs are usually technical replicates to be merged.'
+            help: 'Define if you want to start pipeline from FASTQ files. Pipeline can start from any type of inputs (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined. Especially for FASTQs, we have individual variable for each biological replicate to allow FASTQs of technical replicates can be merged. Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep1_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep1_R1: {
+        fastqs_rep1_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 1.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
@@ -287,7 +287,7 @@ workflow atac {
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep2_R1: {
+        fastqs_rep2_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 2.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
@@ -297,7 +297,7 @@ workflow atac {
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep3_R1: {
+        fastqs_rep3_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 3.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
@@ -307,7 +307,7 @@ workflow atac {
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep4_R1: {
+        fastqs_rep4_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 4.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
@@ -317,7 +317,7 @@ workflow atac {
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep5_R1: {
+        fastqs_rep5_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 5.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
@@ -327,7 +327,7 @@ workflow atac {
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
         }
-        fastqs_rep6_R1: {
+        fastqs_rep6_R2: {
             description: 'Read2 FASTQs to be merged for a biological replicate 6.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
@@ -458,8 +458,8 @@ workflow atac {
             description: 'Enables TSS enrichment plot generation.',
             group: 'pipeline_parameter'
         }
-        enable_tss_enrich: {
-            description: 'Enables annotation enrichment analysis.',
+        enable_annot_enrich: {
+            description: 'Enables annotated regions enrichment analysis.',
             group: 'pipeline_parameter'
         }
         enable_jsd: {
@@ -483,19 +483,19 @@ workflow atac {
         auto_detect_adapter: {
             description: 'Auto-detect/trim adapter sequences.',
             group: 'adapter_trimming',
-            help: 'Can detect three types of adapter sequences. Illumina: AGATCGGAAGAGC, Nextera: CTGTCTCTTATA, smallRNA: TGGAATTCTCGG.'
+            help: 'Can detect/trim three types of adapter sequences. Illumina: AGATCGGAAGAGC, Nextera: CTGTCTCTTATA, smallRNA: TGGAATTCTCGG.'
         }
         adapter: {
             description: 'Adapter for all FASTQs.',
             group: 'adapter_trimming',
-            help: 'Define if all FASTQs have the same adapter sequence. Otherwise define adapter sequence for individual FASTQ in atac.adapters_repX_R1 and atac.adapters_repX_R2 instead. Use atac.auto_detect_adapter if you want to detect adapters automatically.'
+            help: 'Define if all FASTQs have the same adapter sequence. Otherwise define adapter sequence for individual FASTQ in atac.adapters_repX_R1 and atac.adapters_repX_R2 instead. Use atac.auto_detect_adapter if you want to detect adapters automatically. If all of your FASTQs are already trimmed then leave all adapter-related parameters undefined/empty.'
         }
         adapters_rep1_R1: {
             description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep1_R2). You can combine this with atac.auto_detect_adapter. Pipeline will auto-detect/trim adapter sequences for null entry in this list. e.g. ["AAGGCCTT", null, "AAGGCCTT"].'
         }
-        adapters_rep1_R1: {
+        adapters_rep1_R2: {
             description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep1_R1).'
@@ -505,7 +505,7 @@ workflow atac {
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep2_R2).'
         }
-        adapters_rep2_R1: {
+        adapters_rep2_R2: {
             description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 2.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep2_R1).'
@@ -515,7 +515,7 @@ workflow atac {
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep3_R2).'
         }
-        adapters_rep3_R1: {
+        adapters_rep3_R2: {
             description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 3.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep3_R1).'
@@ -525,7 +525,7 @@ workflow atac {
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep4_R2).'
         }
-        adapters_rep4_R1: {
+        adapters_rep4_R2: {
             description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 4.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep4_R1).'
@@ -535,7 +535,7 @@ workflow atac {
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep5_R2).'
         }
-        adapters_rep5_R1: {
+        adapters_rep5_R2: {
             description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 5.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep5_R1).'
@@ -545,7 +545,7 @@ workflow atac {
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep6_R2).'
         }
-        adapters_rep6_R1: {
+        adapters_rep6_R2: {
             description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 6.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep6_R1).'
@@ -607,9 +607,9 @@ workflow atac {
             help: 'Duplicate reads are filtererd out during filtering BAMs to gerenate NODUP_BAM. This flag will keep all duplicate reads in NODUP_BAM. This flag does not affect naming of NODUP_BAM. NODUP_BAM will still have .nodup. suffix in its filename.'
         }
         mapq_thresh: {
-            description: 'Threshold for low MAPQ reads removal',
+            description: 'Threshold for low MAPQ reads removal.',
             group: 'alignment',
-            help: 'Low MAPQ reads are filtered out while filtering BAM.',
+            help: 'Low MAPQ reads are filtered out while filtering BAM.'
         }
         filter_chrs: {
             description: 'List of chromosomes to be filtered out while filtering BAM.',

--- a/atac.wdl
+++ b/atac.wdl
@@ -1,2575 +1,2575 @@
 version 1.0
 
 workflow atac {
-	String pipeline_ver = 'v1.7.1'
-
-	meta {
-		author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
-		description: 'ATAC-Seq/DNase-Seq pipeline'
-		specification_document: 'https://docs.google.com/document/d/1f0Cm4vRyDQDu0bMehHD7P7KOMxTOP-HiNoIvL1VcBt8/edit?usp=sharing'
-
-		caper_docker: 'quay.io/encode-dcc/atac-seq-pipeline:v1.7.1'
-		caper_singularity: 'docker://quay.io/encode-dcc/atac-seq-pipeline:v1.7.1'
-		croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/atac.croo.v4.json'
-	}
-	input {
-		# group: pipeline_metadata
-		String title = 'Untitled'
-		String description = 'No description'
-
-		# group: reference_genome
-		File? genome_tsv
-		String? genome_name
-		File? ref_fa
-		File? ref_mito_fa
-		File? bowtie2_idx_tar
-		File? bowtie2_mito_idx_tar
-		File? chrsz
-		File? blacklist
-		File? blacklist2
-		String? mito_chr_name
-		String? regex_bfilt_peak_chr_name
-		String? gensz
-		File? tss
-		File? dnase
-		File? prom
-		File? enh
-		File? reg2map
-		File? reg2map_bed
-		File? roadmap_meta
-
-		# group: input_genomic_data
-		Boolean? paired_end
-		Array[Boolean] paired_ends = []
-		Array[File] fastqs_rep1_R1 = []
-		Array[File] fastqs_rep1_R2 = []
-		Array[File] fastqs_rep2_R1 = []
-		Array[File] fastqs_rep2_R2 = []
-		Array[File] fastqs_rep3_R1 = []
-		Array[File] fastqs_rep3_R2 = []
-		Array[File] fastqs_rep4_R1 = []
-		Array[File] fastqs_rep4_R2 = []
-		Array[File] fastqs_rep5_R1 = []
-		Array[File] fastqs_rep5_R2 = []
-		Array[File] fastqs_rep6_R1 = []
-		Array[File] fastqs_rep6_R2 = []
-		Array[File] fastqs_rep7_R1 = []
-		Array[File] fastqs_rep7_R2 = []
-		Array[File] fastqs_rep8_R1 = []
-		Array[File] fastqs_rep8_R2 = []
-		Array[File] fastqs_rep9_R1 = []
-		Array[File] fastqs_rep9_R2 = []
-		Array[File] fastqs_rep10_R1 = []
-		Array[File] fastqs_rep10_R2 = []
-		Array[File?] bams = []
-		Array[File?] nodup_bams = []
-		Array[File?] tas = []
-		Array[File?] peaks = []
-		Array[File?] peaks_pr1 = []
-		Array[File?] peaks_pr2 = []
-		File? peak_pooled
-		File? peak_ppr1
-		File? peak_ppr2
-
-		# group: pipeline_parameter
-		String pipeline_type = 'atac'
-		Boolean align_only = false
-		Boolean true_rep_only = false
-		Boolean enable_xcor = false
-		Boolean enable_count_signal_track = false
-		Boolean enable_idr = true
-		Boolean enable_preseq = false
-		Boolean enable_fraglen_stat = true
-		Boolean enable_tss_enrich = true
-		Boolean enable_annot_enrich = true
-		Boolean enable_jsd = true
-		Boolean enable_compare_to_roadmap = false
-		Boolean enable_gc_bias = true
-
-		# group: adapter_trimming
-		String cutadapt_param = '-e 0.1 -m 5'
-		Boolean auto_detect_adapter = false
-		String? adapter
-		Array[String] adapters_rep1_R1 = []
-		Array[String] adapters_rep1_R2 = []
-		Array[String] adapters_rep2_R1 = []
-		Array[String] adapters_rep2_R2 = []
-		Array[String] adapters_rep3_R1 = []
-		Array[String] adapters_rep3_R2 = []
-		Array[String] adapters_rep4_R1 = []
-		Array[String] adapters_rep4_R2 = []
-		Array[String] adapters_rep5_R1 = []
-		Array[String] adapters_rep5_R2 = []
-		Array[String] adapters_rep6_R1 = []
-		Array[String] adapters_rep6_R2 = []
-		Array[String] adapters_rep7_R1 = []
-		Array[String] adapters_rep7_R2 = []
-		Array[String] adapters_rep8_R1 = []
-		Array[String] adapters_rep8_R2 = []
-		Array[String] adapters_rep9_R1 = []
-		Array[String] adapters_rep9_R2 = []
-		Array[String] adapters_rep10_R1 = []
-		Array[String] adapters_rep10_R2 = []
-
-		# group: alignment
-		Int multimapping = 4
-		String dup_marker = 'picard'
-		Boolean no_dup_removal = false
-		Int mapq_thresh = 30
-		Array[String] filter_chrs = ['chrM', 'MT']
-		Int subsample_reads = 0
-		Int xcor_subsample_reads = 25000000
-		Array[Int?] read_len = []
-
-		# group: peak_calling
-		Int cap_num_peak = 300000
-		Float pval_thresh = 0.01
-		Int smooth_win = 150
-		Float idr_thresh = 0.05
-
-		# group: resource_parameter
-		Int align_cpu = 4
-		Int align_mem_mb = 20000
-		Int align_time_hr = 48
-		String align_disks = 'local-disk 400 HDD'
-
-		Int filter_cpu = 2
-		Int filter_mem_mb = 20000
-		Int filter_time_hr = 24
-		String filter_disks = 'local-disk 400 HDD'
-
-		Int bam2ta_cpu = 2
-		Int bam2ta_mem_mb = 10000
-		Int bam2ta_time_hr = 6
-		String bam2ta_disks = 'local-disk 100 HDD'
-
-		Int spr_mem_mb = 16000
-
-		Int jsd_cpu = 2
-		Int jsd_mem_mb = 12000
-		Int jsd_time_hr = 6
-		String jsd_disks = 'local-disk 200 HDD'
-
-		Int xcor_cpu = 2
-		Int xcor_mem_mb = 16000
-		Int xcor_time_hr = 6
-		String xcor_disks = 'local-disk 100 HDD'
-
-		Int call_peak_cpu = 1
-		Int call_peak_mem_mb = 16000
-		Int call_peak_time_hr = 24
-		String call_peak_disks = 'local-disk 200 HDD'
-
-		Int macs2_signal_track_mem_mb = 16000
-		Int macs2_signal_track_time_hr = 24
-		String macs2_signal_track_disks = 'local-disk 400 HDD'
-
-		Int preseq_mem_mb = 16000
-
-		String? filter_picard_java_heap
-		String? preseq_picard_java_heap
-		String? fraglen_stat_picard_java_heap
-		String? gc_bias_picard_java_heap
-	}
-
-	parameter_meta {
-		title: {
-			description: 'Experiment title.',
-			group: 'pipeline_metadata',
-		}
-		description: {
-			description: 'Experiment description.',
-			group: 'pipeline_metadata',
-		}
-		genome_tsv: {
-			description: 'Reference genome database TSV.',
-			group: 'reference_genome',
-			help: 'This TSV files includes all genome specific parameters (e.g. reference FASTA, bowtie2 index). You can still invidiaully define any parameters in it. Parameters defined in input JSON will override those defined in genome TSV.'
-		}
-		genome_name: {
-			description: 'Genome name.',
-			group: 'reference_genome'
-		}
-		ref_fa: {
-			description: 'Reference FASTA file.',
-			group: 'reference_genome'
-		}
-		ref_mito_fa: {
-			description: 'Reference FASTA file (mitochondrial reads only).',
-			group: 'reference_genome'
-		}
-		bowtie2_idx_tar: {
-			description: 'BWA index TAR file.',
-			group: 'reference_genome'
-		}
-		bowtie2_mito_idx_tar: {
-			description: 'BWA index TAR file (mitochondrial reads only).',
-			group: 'reference_genome'
-		}
-		chrsz: {
-			description: '2-col chromosome sizes file.',
-			group: 'reference_genome'
-		}
-		blacklist: {
-			description: 'Blacklist file in BED format.',
-			group: 'reference_genome',
-			help: 'Peaks will be filtered with this file.'
-		}
-		blacklist2: {
-			description: 'Secondary blacklist file in BED format.',
-			group: 'reference_genome',
-			help: 'If it is defined, it will be merged with atac.blacklist. Peaks will be filtered with merged blacklist.'
-		}
-		mito_chr_name: {
-			description: 'Mitochondrial chromosome name.',
-			group: 'reference_genome',
-			help: 'e.g. chrM, MT. Mitochondrial reads defined here will be filtered out during filtering BAMs in "filter" task.'
-		}
-		regex_bfilt_peak_chr_name: {
-			description: 'Reg-ex for chromosomes to keep while filtering peaks.',
-			group: 'reference_genome',
-			help: 'Chromosomes defined here will be kept. All other chromosomes will be filtered out in .bfilt. peak file. This is done along with blacklist filtering peak file.'
-		}
-		gensz: {
-			description: 'Genome sizes. "hs" for human, "mm" for mouse or sum of 2nd columnin chromosome sizes file.',
-			group: 'reference_genome'
-		}
-		tss: {
-			description: 'TSS file in BED format.',
-			group: 'reference_genome'
-		}
-		dnase: {
-			description: 'Open chromatin regions file in BED format.',
-			group: 'reference_genome'
-		}
-		prom: {
-			description: 'Promoter regions file in BED format.',
-			group: 'reference_genome'
-		}
-		enh: {
-			description: 'Enhancer regions file in BED format.',
-			group: 'reference_genome'
-		}
-		reg2map: {
-			description: 'Cell type signals file.',
-			group: 'reference_genome'
-		}
-		reg2map_bed: {
-			description: 'File of regions used to generate reg2map signals.',
-			group: 'reference_genome'
-		}
-		roadmap_meta: {
-			description: 'Roadmap metadata.',
-			group: 'reference_genome'
-		}
-		paired_end: {
-			description: 'Sequencing endedness.',
-			group: 'input_genomic_data',
-			help: 'Setting this on means that all replicates are paired ended. For mixed samples, use atac.paired_ends array instead.'
-		}
-		paired_ends: {
-			description: 'Sequencing endedness array (for mixed SE/PE datasets).',
-			group: 'input_genomic_data',
-			help: 'Whether each biological replicate is paired ended or not.'
-		}
-		fastqs_rep1_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of inputs (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined. Especially for FASTQs, we have individual variable for each biological replicate to allow FASTQs of technical replicates can be merged. Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep1_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep1_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep2_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 2.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep2_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 2.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep3_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 3.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep3_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 3.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep4_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 4.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep4_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 4.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep5_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 5.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep5_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 5.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep6_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 6.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep6_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 6.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep7_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 7.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep7_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep7_R2: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 7.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep7_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep8_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 8.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep8_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep8_R2: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 8.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep8_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep9_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 9.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep9_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep9_R2: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 9.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep9_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep10_R1: {
-			description: 'Read1 FASTQs to be merged for a biological replicate 10.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep10_R2). These FASTQs are usually technical replicates to be merged.'
-		}
-		fastqs_rep10_R2: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 10.',
-			group: 'input_genomic_data',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep10_R1). These FASTQs are usually technical replicates to be merged.'
-		}
-		bams: {
-			description: 'List of unfiltered/raw BAM files for each biological replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from BAM files. Unfiltered/raw BAM file generated from aligner (e.g. bowtie2). Each entry for each biological replicate. e.g. [rep1.bam, rep2.bam, rep3.bam, ...].'
-		}
-		nodup_bams: {
-			description: 'List of filtered/deduped BAM files for each biological replicate',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from filtered BAM files. Filtered/deduped BAM file. Each entry for each biological replicate. e.g. [rep1.nodup.bam, rep2.nodup.bam, rep3.nodup.bam, ...].'
-		}
-		tas: {
-			description: 'List of TAG-ALIGN files for each biological replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from TAG-ALIGN files. TAG-ALIGN is in a 6-col BED format. It is a simplified version of BAM. Each entry for each biological replicate. e.g. [rep1.tagAlign.gz, rep2.tagAlign.gz, ...].'
-		}
-		peaks: {
-			description: 'List of NARROWPEAK files (not blacklist filtered) for each biological replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Each entry for each biological replicate. e.g. [rep1.narrowPeak.gz, rep2.narrowPeak.gz, ...]. Define other PEAK parameters (e.g. atac.peaks_pr1, atac.peak_pooled) according to your flag settings (e.g. atac.true_rep_only) and number of replicates. If you have more than one replicate then define atac.peak_pooled, atac.peak_ppr1 and atac.peak_ppr2. If atac.true_rep_only flag is on then do not define any parameters (atac.peaks_pr1, atac.peaks_pr2, atac.peak_ppr1 and atac.peak_ppr2) related to pseudo replicates.'
-		}
-		peaks_pr1: {
-			description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 1 of each biological replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Define if atac.true_rep_only flag is off.'
-		}
-		peaks_pr2: {
-			description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 2 of each biological replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Define if atac.true_rep_only flag is off.'
-		}
-		peak_pooled: {
-			description: 'NARROWPEAK file for pooled true replicate.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates. Pooled true replicate means analysis on pooled biological replicates.'
-		}
-		peak_ppr1: {
-			description: 'NARROWPEAK file for pooled pseudo replicate 1.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and atac.truerep_only flag is off. PPR1 means analysis on pooled 1st pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 1st pseudos.'
-		}
-		peak_ppr2: {
-			description: 'NARROWPEAK file for pooled pseudo replicate 2.',
-			group: 'input_genomic_data',
-			help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and atac.truerep_only flag is off. PPR1 means analysis on pooled 2nd pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 2nd pseudos.'
-		}
-
-		pipeline_type: {
-			description: 'Pipeline type. atac for ATAC-Seq or dnase for DNase-Seq.',
-			group: 'pipeline_parameter',
-			help: 'The only difference of two types is that TN5 shifting of TAG-ALIGN is done for atac. TAG-ALIGN is in 6-col BED format. It is a simplified version of BAM.'
-		}
-		align_only: {
-			description: 'Align only mode.',
-			group: 'pipeline_parameter',
-			help: 'Reads will be aligned but there will be no peak-calling on them.'
-		}
-		true_rep_only: {
-			description: 'Disables all analyses related to pseudo-replicates.',
-			group: 'pipeline_parameter',
-			help: 'Pipeline generates 2 pseudo-replicate from one biological replicate. This flag turns off all analyses related to pseudos (with prefix/suffix pr, ppr).'
-		}
-		enable_xcor: {
-			description: 'Enables cross-correlation analysis.',
-			group: 'pipeline_parameter',
-			help: 'Generates cross-correlation plot.'
-		}
-		enable_count_signal_track: {
-			description: 'Enables generation of count signal tracks.',
-			group: 'pipeline_parameter'
-		}
-		enable_idr: {
-			description: 'Enables IDR on MACS2 NARROWPEAKs.',
-			group: 'pipeline_parameter'
-		}
-		enable_preseq: {
-			description: 'Enables preseq analysis.',
-			group: 'pipeline_parameter'
-		}
-		enable_fraglen_stat: {
-			description: 'Enables calculation of fragment length distribution/statistics.',
-			group: 'pipeline_parameter'
-		}
-		enable_tss_enrich: {
-			description: 'Enables TSS enrichment plot generation.',
-			group: 'pipeline_parameter'
-		}
-		enable_tss_enrich: {
-			description: 'Enables annotation enrichment analysis.',
-			group: 'pipeline_parameter'
-		}
-		enable_jsd: {
-			description: 'Enables Jensen-Shannon Distance (JSD) plot generation.',
-			group: 'pipeline_parameter'
-		}
-		enable_compare_to_roadmap: {
-			description: 'Enables comparison to Roadmap.',
-			group: 'pipeline_parameter'
-		}
-		enable_gc_bias: {
-			description: 'Enables GC bias calculation.',
-			group: 'pipeline_parameter'
-		}
-
-		cutadapt_param: {
-			description: 'Parameters for cutadapt.',
-			group: 'adapter_trimming',
-			help: 'It is -e 0.1 -m 5 by default (err_rate=0.1, min_trim_len=5). You can define any parameters that cutadapt supports.'
-		}
-		auto_detect_adapter: {
-			description: 'Auto-detect/trim adapter sequences.',
-			group: 'adapter_trimming',
-			help: 'Can detect three types of adapter sequences. Illumina: AGATCGGAAGAGC, Nextera: CTGTCTCTTATA, smallRNA: TGGAATTCTCGG.'
-		}
-		adapter: {
-			description: 'Adapter for all FASTQs.',
-			group: 'adapter_trimming',
-			help: 'Define if all FASTQs have the same adapter sequence. Otherwise define adapter sequence for individual FASTQ in atac.adapters_repX_R1 and atac.adapters_repX_R2 instead. Use atac.auto_detect_adapter if you want to detect adapters automatically.'
-		}
-		adapters_rep1_R1: {
-			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep1_R2). You can combine this with atac.auto_detect_adapter. Pipeline will auto-detect/trim adapter sequences for null entry in this list. e.g. ["AAGGCCTT", null, "AAGGCCTT"].'
-		}
-		adapters_rep1_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep1_R1).'
-		}
-		adapters_rep2_R1: {
-			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep2_R2).'
-		}
-		adapters_rep2_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep2_R1).'
-		}
-		adapters_rep3_R1: {
-			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep3_R2).'
-		}
-		adapters_rep3_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep3_R1).'
-		}
-		adapters_rep4_R1: {
-			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep4_R2).'
-		}
-		adapters_rep4_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep4_R1).'
-		}
-		adapters_rep5_R1: {
-			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep5_R2).'
-		}
-		adapters_rep5_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep5_R1).'
-		}
-		adapters_rep6_R1: {
-			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep6_R2).'
-		}
-		adapters_rep6_R1: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep6_R1).'
-		}
-		adapters_rep7_R1: {
-			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep7_R2).'
-		}
-		adapters_rep7_R2: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep7_R1).'
-		}
-		adapters_rep8_R1: {
-			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep8_R2).'
-		}
-		adapters_rep8_R2: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep8_R1).'
-		}
-		adapters_rep9_R1: {
-			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep9_R2).'
-		}
-		adapters_rep9_R2: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep9_R1).'
-		}
-		adapters_rep10_R1: {
-			description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep10_R2).'
-		}
-		adapters_rep10_R2: {
-			description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
-			group: 'adapter_trimming',
-			help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep10_R1).'
-		}
-
-		multimapping: {
-			description: 'Number of multimappers.',
-			group: 'alignment',
-			help: 'It is 4 by default. Set it to 0 if your sample does not have multimappers.'
-		}
-		dup_marker: {
-			description: 'Marker for duplicate reads. picard or sambamba.',
-			group: 'alignment',
-			help: 'picard for Picard MarkDuplicates or sambamba for sambamba markdup.'
-		}
-		no_dup_removal: {
-			description: 'Disable removal of duplicate reads during filtering BAM.',
-			group: 'alignment',
-			help: 'Duplicate reads are filtererd out during filtering BAMs to gerenate NODUP_BAM. This flag will keep all duplicate reads in NODUP_BAM. This flag does not affect naming of NODUP_BAM. NODUP_BAM will still have .nodup. suffix in its filename.'
-		}
-		mapq_thresh: {
-			description: 'Threshold for low MAPQ reads removal',
-			group: 'alignment',
-			help: 'Low MAPQ reads are filtered out while filtering BAM.',
-		}
-		filter_chrs: {
-			description: 'List of chromosomes to be filtered out while filtering BAM.',
-			group: 'alignment',
-			help: 'It is ["chrM", "MT"] by default. Therefore, mitochondrial reads will be filtered out while filtering. Make it empty if you want to keep all reads.'
-		}
-		subsample_reads: {
-			description: 'Subsample reads. Shuffle and subsample reads.',
-			group: 'alignment',
-			help: 'This affects all downstream analyses after filtering BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number.'
-		}
-		xcor_subsample_reads: {
-			description: 'Subsample reads for cross-corrlelation analysis only.',
-			group: 'alignment',
-			help: 'This does not affect downstream analyses after filtering BAM. It is for cross-correlation analysis only.'
-		}
-		read_len: {
-			description: 'Read length per biological replicate.',
-			group: 'alignment',
-			help: 'Pipeline can estimate read length from FASTQs. If you start pipeline from other types (BAM, NODUP_BAM, TA, ...) than FASTQ. Then provide this for some analyses that require read length (e.g. TSS enrichment plot).'
-		}
-
-		cap_num_peak: {
-			description: 'Upper limit on the number of peaks.',
-			group: 'peak_calling',
-			help: 'Called peaks will be sorted in descending order of score and the number of peaks will be capped at this number by taking first N peaks.'
-		}
-		pval_thresh: {
-			description: 'p-value Threshold for MACS2 peak caller.',
-			group: 'peak_calling',
-			help: 'macs2 callpeak -p'
-		}
-		smooth_win: {
-			description: 'Size of smoothing windows for MACS2 peak caller.',
-			group: 'peak_calling',
-			help: 'This will be used for both generating MACS2 peaks/signal tracks.'
-		}
-		idr_thresh: {
-			description: 'IDR threshold.',
-			group: 'peak_calling'
-		}
-
-		align_cpu: {
-			description: 'Number of cores for task align.',
-			group: 'resource_parameter',
-			help: 'Task align merges/crops/maps FASTQs.'
-		}
-		align_mem_mb: {
-			description: 'Memory (MB) required for task align.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		align_time_hr: {
-			description: 'Walltime (h) required for task align.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		align_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task align.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		filter_cpu: {
-			description: 'Number of cores for task filter.',
-			group: 'resource_parameter',
-			help: 'Task filter filters raw/unfilterd BAM to get filtered/deduped BAM.'
-		}
-		filter_mem_mb: {
-			description: 'Memory (MB) required for task filter.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		filter_time_hr: {
-			description: 'Walltime (h) required for task filter.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		filter_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task filter.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		bam2ta_cpu: {
-			description: 'Number of cores for task bam2ta.',
-			group: 'resource_parameter',
-			help: 'Task bam2ta converts filtered/deduped BAM in to TAG-ALIGN (6-col BED) format.'
-		}
-		bam2ta_mem_mb: {
-			description: 'Memory (MB) required for task bam2ta.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		bam2ta_time_hr: {
-			description: 'Walltime (h) required for task bam2ta.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		bam2ta_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task bam2ta.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		spr_mem_mb: {
-			description: 'Memory (MB) required for task spr.',
-			group: 'resource_parameter',
-			help: 'Task spr generates two pseudo-replicates from each biological replicate. This task uses Unix shuf/sort, which can take significant amount of memory.'
-		}
-		jsd_cpu: {
-			description: 'Number of cores for task jsd.',
-			group: 'resource_parameter',
-			help: 'Task jsd plots Jensen-Shannon distance and metrics related to it.'
-		}
-		jsd_mem_mb: {
-			description: 'Memory (MB) required for task jsd.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		jsd_time_hr: {
-			description: 'Walltime (h) required for task jsd.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		jsd_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task jsd.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		xcor_cpu: {
-			description: 'Number of cores for task xcor.',
-			group: 'resource_parameter',
-			help: 'Task xcor does cross-correlation analysis (including a plot) on subsampled TAG-ALIGNs.'
-		}
-		xcor_mem_mb: {
-			description: 'Memory (MB) required for task xcor.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		xcor_time_hr: {
-			description: 'Walltime (h) required for task xcor.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		xcor_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task xcor.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		call_peak_cpu: {
-			description: 'Number of cores for task call_peak.',
-			group: 'resource_parameter',
-			help: 'Task call_peak call peaks on TAG-ALIGNs by using MACS2 peak caller.'
-		}
-		call_peak_mem_mb: {
-			description: 'Memory (MB) required for task call_peak.',
-			group: 'resource_parameter',
-			help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		call_peak_time_hr: {
-			description: 'Walltime (h) required for task call_peak.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		call_peak_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task call_peak.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		macs2_signal_track_mem_mb: {
-			description: 'Memory (MB) required for task macs2_signal_track.',
-			group: 'resource_parameter',
-			help: 'Task macs2_signal_track_mem_mb uses MACS2 to get signal tracks for p-val (suffixed with .pval.) and fold enrichment (suffixed with .fc.). This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		macs2_signal_track_time_hr: {
-			description: 'Walltime (h) required for task macs2_signal_track.',
-			group: 'resource_parameter',
-			help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
-		}
-		macs2_signal_track_disks: {
-			description: 'Persistent disk size to store intermediate files and outputs of task macs2_signal_track.',
-			group: 'resource_parameter',
-			help: 'This is for GCP/AWS only.'
-		}
-		preseq_mem_mb: {
-			description: 'Memory (MB) required for task preseq.',
-			group: 'resource_parameter',
-			help: 'Task preseq estimates the future yield of a genomic library. This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
-		}
-		filter_picard_java_heap: {
-			description: 'Maximum Java heap (java -Xmx) in task filter.',
-			group: 'resource_parameter',
-			help: 'Maximum memory for Picard tools MarkDuplicates. If not defined, 90% of filter_mem_mb will be used.'
-		}
-		preseq_picard_java_heap: {
-			description: 'Maximum Java heap (java -Xmx) in task preseq.',
-			group: 'resource_parameter',
-			help: 'Maximum memory for Picard tools EstimateLibraryComplexity. If not defined, 90% of preseq_mem_mb will be used.'
-		}
-		fraglen_stat_picard_java_heap: {
-			description: 'Maximum Java heap (java -Xmx) in task fraglen_stat_pe (for paired end replicate only).',
-			group: 'resource_parameter',
-			help: 'Maximum memory for Picard tools CollectInsertSizeMetrics. If not defined, 90% of 8000 MB will be used.'
-		}
-		gc_bias_picard_java_heap: {
-			description: 'Maximum Java heap (java -Xmx) in task gc_bias.',
-			group: 'resource_parameter',
-			help: 'Maximum memory for Picard tools CollectGcBiasMetrics. If not defined, 90% of 10000 MB will be used.'
-		}
-	}
-
-	String aligner = 'bowtie2'
-	String peak_caller = 'macs2'
-	String peak_type = 'narrowPeak'
-	
-	# read genome data and paths
-	if ( defined(genome_tsv) ) {
-		call read_genome_tsv { input: genome_tsv = genome_tsv }
-	}
-	File ref_fa_ = select_first([ref_fa, read_genome_tsv.ref_fa])
-	File bowtie2_idx_tar_ = select_first([bowtie2_idx_tar, read_genome_tsv.bowtie2_idx_tar])
-	File bowtie2_mito_idx_tar_ = select_first([bowtie2_mito_idx_tar, read_genome_tsv.bowtie2_mito_idx_tar])
-	File chrsz_ = select_first([chrsz, read_genome_tsv.chrsz])
-	String gensz_ = select_first([gensz, read_genome_tsv.gensz])
-	File? blacklist1_ = if defined(blacklist) then blacklist
-		else read_genome_tsv.blacklist
-	File? blacklist2_ = if defined(blacklist2) then blacklist2
-		else read_genome_tsv.blacklist2		
-	# merge multiple blacklists
-	# two blacklists can have different number of columns (3 vs 6)
-	# so we limit merged blacklist's columns to 3
-	Array[File] blacklists = select_all([blacklist1_, blacklist2_])
-	if ( length(blacklists) > 1 ) {
-		call pool_ta as pool_blacklist { input:
-			tas = blacklists,
-			col = 3,
-		}
-	}
-	File? blacklist_ = if length(blacklists) > 1 then pool_blacklist.ta_pooled
-		else if length(blacklists) > 0 then blacklists[0]
-		else blacklist2_
-	String mito_chr_name_ = select_first([mito_chr_name, read_genome_tsv.mito_chr_name])
-	String regex_bfilt_peak_chr_name_ = select_first([regex_bfilt_peak_chr_name, read_genome_tsv.regex_bfilt_peak_chr_name])
-	String genome_name_ = select_first([genome_name, read_genome_tsv.genome_name, basename(chrsz_)])
-
-	# read additional annotation data
-	File? tss_ = if defined(tss) then tss
-		else read_genome_tsv.tss
-	File? dnase_ = if defined(dnase) then dnase
-		else read_genome_tsv.dnase
-	File? prom_ = if defined(prom) then prom
-		else read_genome_tsv.prom
-	File? enh_ = if defined(enh) then enh
-		else read_genome_tsv.enh
-	File? reg2map_ = if defined(reg2map) then reg2map
-		else read_genome_tsv.reg2map
-	File? reg2map_bed_ = if defined(reg2map_bed) then reg2map_bed
-		else read_genome_tsv.reg2map_bed
-	File? roadmap_meta_ = if defined(roadmap_meta) then roadmap_meta
-		else read_genome_tsv.roadmap_meta
-
-	### temp vars (do not define these)
-	String aligner_ = aligner
-	String peak_caller_ = peak_caller
-	String peak_type_ = peak_type
-	String idr_rank_ = if peak_caller_=='spp' then 'signal.value'
-						else if peak_caller_=='macs2' then 'p.value'
-						else 'p.value'
-	Int cap_num_peak_ = cap_num_peak
-	Int mapq_thresh_ = mapq_thresh
-
-	# temporary 2-dim fastqs array [rep_id][merge_id]
-	Array[Array[File]] fastqs_R1 = 
-		if length(fastqs_rep10_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
-			fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1, fastqs_rep9_R1, fastqs_rep10_R1]
-		else if length(fastqs_rep9_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
-			fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1, fastqs_rep9_R1]
-		else if length(fastqs_rep8_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
-			fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1]
-		else if length(fastqs_rep7_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
-			fastqs_rep6_R1, fastqs_rep7_R1]
-		else if length(fastqs_rep6_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
-			fastqs_rep6_R1]
-		else if length(fastqs_rep5_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1]
-		else if length(fastqs_rep4_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1]
-		else if length(fastqs_rep3_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1]
-		else if length(fastqs_rep2_R1)>0 then
-			[fastqs_rep1_R1, fastqs_rep2_R1]
-		else if length(fastqs_rep1_R1)>0 then
-			[fastqs_rep1_R1]
-		else []
-	# no need to do that for R2 (R1 array will be used to determine presense of fastq for each rep)
-	Array[Array[File]] fastqs_R2 = 
-		[fastqs_rep1_R2, fastqs_rep2_R2, fastqs_rep3_R2, fastqs_rep4_R2, fastqs_rep5_R2,
-		fastqs_rep6_R2, fastqs_rep7_R2, fastqs_rep8_R2, fastqs_rep9_R2, fastqs_rep10_R2]
-
-	# temporary 2-dim adapters array [rep_id][merge_id]
-	Array[Array[String]] adapters_R1 = 
-		[adapters_rep1_R1, adapters_rep2_R1, adapters_rep3_R1, adapters_rep4_R1, adapters_rep5_R1,
-		adapters_rep6_R1, adapters_rep7_R1, adapters_rep8_R1, adapters_rep9_R1, adapters_rep10_R1]
-	Array[Array[String]] adapters_R2 = 
-		[adapters_rep1_R2, adapters_rep2_R2, adapters_rep3_R2, adapters_rep4_R2, adapters_rep5_R2,
-		adapters_rep6_R2, adapters_rep7_R2, adapters_rep8_R2, adapters_rep9_R2, adapters_rep10_R2]
-
-	# temporary variables to get number of replicates
-	#	   WDLic implementation of max(A,B,C,...)
-	Int num_rep_fastq = length(fastqs_R1)
-	Int num_rep_bam = if length(bams)<num_rep_fastq then num_rep_fastq
-		else length(bams)
-	Int num_rep_nodup_bam = if length(nodup_bams)<num_rep_bam then num_rep_bam
-		else length(nodup_bams)
-	Int num_rep_ta = if length(tas)<num_rep_nodup_bam then num_rep_nodup_bam
-		else length(tas)
-	Int num_rep_peak = if length(peaks)<num_rep_ta then num_rep_ta
-		else length(peaks)
-	Int num_rep = num_rep_peak
-
-	# sanity check for inputs
-	if ( num_rep == 0 ) {
-		call raise_exception as error_input_data  { input:
-			msg = 'No FASTQ/BAM/TAG-ALIGN/PEAK defined in your input JSON. Check if your FASTQs are defined as "atac.fastqs_repX_RY". DO NOT MISS suffix _R1 even for single ended FASTQ.'
-		}
-	}
-
-	# align each replicate
-	scatter(i in range(num_rep)) {
-		# to override endedness definition for individual replicate
-		#	 paired_end will override paired_ends[i]
-		Boolean paired_end_ = if !defined(paired_end) && i<length(paired_ends) then paired_ends[i]
-			else select_first([paired_end])
-
-		Boolean has_input_of_align = i<length(fastqs_R1) && length(fastqs_R1[i])>0
-		Boolean has_output_of_align = i<length(bams) && defined(bams[i])
-		if ( has_input_of_align && !has_output_of_align ) {
-			call align { input :
-				fastqs_R1 = fastqs_R1[i],
-				fastqs_R2 = fastqs_R2[i],
-				adapter = adapter,
-				adapters_R1 = adapters_R1[i],
-				adapters_R2 = adapters_R2[i],
-				paired_end = paired_end_,
-				auto_detect_adapter = auto_detect_adapter,
-				cutadapt_param = cutadapt_param,
-
-				aligner = aligner_,
-				mito_chr_name = mito_chr_name_,
-				chrsz = chrsz_,
-				multimapping = multimapping,
-				idx_tar = bowtie2_idx_tar_,
-				# resource
-				cpu = align_cpu,
-				mem_mb = align_mem_mb,
-				time_hr = align_time_hr,
-				disks = align_disks,
-			}
-		}
-		File? bam_ = if has_output_of_align then bams[i] else align.bam
-
-		# mito only mapping to get frac mito qc
-		Boolean has_input_of_align_mito = has_input_of_align &&
-			defined(bowtie2_mito_idx_tar_)
-		if ( has_input_of_align_mito ) {
-			call align as align_mito { input :
-				fastqs_R1 = fastqs_R1[i],
-				fastqs_R2 = fastqs_R2[i],
-				adapter = adapter,
-				adapters_R1 = adapters_R1[i],
-				adapters_R2 = adapters_R2[i],
-				paired_end = paired_end_,
-				auto_detect_adapter = auto_detect_adapter,
-				cutadapt_param = cutadapt_param,
-
-				aligner = aligner_,
-				mito_chr_name = mito_chr_name_,
-				chrsz = chrsz_,
-				multimapping = multimapping,
-				idx_tar = bowtie2_mito_idx_tar_,
-				# resource
-				cpu = align_cpu,
-				mem_mb = align_mem_mb,
-				time_hr = align_time_hr,
-				disks = align_disks,
-			}
-		}
-
-		if ( defined(align.non_mito_samstat_qc) && defined(align_mito.samstat_qc) ) {
-			call frac_mito { input:
-				non_mito_samstat = align.non_mito_samstat_qc,
-				mito_samstat = align_mito.samstat_qc,
-			}
-		}		
-
-		Boolean has_input_of_filter = has_output_of_align || defined(align.bam)
-		Boolean has_output_of_filter = i<length(nodup_bams) && defined(nodup_bams[i])
-		# skip if we already have output of this step
-		if ( has_input_of_filter && !has_output_of_filter ) {
-			call filter { input :
-				bam = bam_,
-				paired_end = paired_end_,
-				dup_marker = dup_marker,
-				mapq_thresh = mapq_thresh_,
-				filter_chrs = filter_chrs,
-				chrsz = chrsz_,
-				no_dup_removal = no_dup_removal,
-				multimapping = multimapping,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = filter_cpu,
-				mem_mb = filter_mem_mb,
-				picard_java_heap = filter_picard_java_heap,
-				time_hr = filter_time_hr,
-				disks = filter_disks,
-			}
-		}
-		File? nodup_bam_ = if has_output_of_filter then nodup_bams[i] else filter.nodup_bam
-
-		Boolean has_input_of_bam2ta = has_output_of_filter || defined(filter.nodup_bam)
-		Boolean has_output_of_bam2ta = i<length(tas) && defined(tas[i])
-		if ( has_input_of_bam2ta && !has_output_of_bam2ta ) {
-			call bam2ta { input :
-				bam = nodup_bam_,
-				disable_tn5_shift = if pipeline_type=='atac' then false else true,
-				subsample = subsample_reads,
-				paired_end = paired_end_,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = bam2ta_cpu,
-				mem_mb = bam2ta_mem_mb,
-				time_hr = bam2ta_time_hr,
-				disks = bam2ta_disks,
-			}
-		}
-		File? ta_ = if has_output_of_bam2ta then tas[i] else bam2ta.ta
-
-		Boolean has_input_of_xcor = has_output_of_align || defined(align.bam)
-		if ( has_input_of_xcor && enable_xcor ) {
-			call filter as filter_no_dedup { input :
-				bam = bam_,
-				paired_end = paired_end_,
-				dup_marker = dup_marker,
-				mapq_thresh = mapq_thresh_,
-				filter_chrs = filter_chrs,
-				chrsz = chrsz_,
-				no_dup_removal = true,
-				multimapping = multimapping,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = filter_cpu,
-				mem_mb = filter_mem_mb,
-				picard_java_heap = filter_picard_java_heap,
-				time_hr = filter_time_hr,
-				disks = filter_disks,
-			}
-			call bam2ta as bam2ta_no_dedup { input :
-				bam = filter_no_dedup.nodup_bam,  # output name is nodup but it's not deduped
-				disable_tn5_shift = if pipeline_type=='atac' then false else true,
-				subsample = 0,
-				paired_end = paired_end_,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = bam2ta_cpu,
-				mem_mb = bam2ta_mem_mb,
-				time_hr = bam2ta_time_hr,
-				disks = bam2ta_disks,
-			}
-			# subsample tagalign (non-mito) and cross-correlation analysis
-			call xcor { input :
-				ta = bam2ta_no_dedup.ta,
-				subsample = xcor_subsample_reads,
-				paired_end = paired_end_,
-				mito_chr_name = mito_chr_name_,
-
-				cpu = xcor_cpu,
-				mem_mb = xcor_mem_mb,
-				time_hr = xcor_time_hr,
-				disks = xcor_disks,
-			}
-		}
-
-		Boolean has_input_of_macs2_signal_track = has_output_of_bam2ta || defined(bam2ta.ta)
-		if ( has_input_of_macs2_signal_track ) {
-			# generate count signal track
-			call macs2_signal_track { input :
-				ta = ta_,
-				gensz = gensz_,
-				chrsz = chrsz_,
-				pval_thresh = pval_thresh,
-				smooth_win = smooth_win,
-
-				mem_mb = macs2_signal_track_mem_mb,
-				disks = macs2_signal_track_disks,
-				time_hr = macs2_signal_track_time_hr,
-			}
-		}
-
-		Boolean has_input_of_call_peak = has_output_of_bam2ta || defined(bam2ta.ta)
-		Boolean has_output_of_call_peak = i<length(peaks) && defined(peaks[i])
-		if ( has_input_of_call_peak && !has_output_of_call_peak && !align_only ) {
-			# call peaks on tagalign
-			call call_peak { input :
-				peak_caller = peak_caller_,
-				peak_type = peak_type_,
-				ta = ta_,
-				gensz = gensz_,
-				chrsz = chrsz_,
-				cap_num_peak = cap_num_peak_,
-				pval_thresh = pval_thresh,
-				smooth_win = smooth_win,
-				blacklist = blacklist_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-				cpu = call_peak_cpu,
-				mem_mb = call_peak_mem_mb,
-				disks = call_peak_disks,
-				time_hr = call_peak_time_hr,
-			}
-		}
-		File? peak_ = if has_output_of_call_peak then peaks[i] else call_peak.peak
-
-		Boolean has_input_of_spr = has_output_of_bam2ta || defined(bam2ta.ta)
-		if ( has_input_of_spr && !align_only && !true_rep_only ) {
-			call spr { input :
-				ta = ta_,
-				paired_end = paired_end_,
-				mem_mb = spr_mem_mb,
-			}
-		}
-
-		Boolean has_input_of_call_peak_pr1 = defined(spr.ta_pr1)
-		Boolean has_output_of_call_peak_pr1 = i<length(peaks_pr1) && defined(peaks_pr1[i])
-		if ( has_input_of_call_peak_pr1 && !has_output_of_call_peak_pr1 &&
-			!align_only && !true_rep_only ) {
-			# call peaks on 1st pseudo replicated tagalign 
-			call call_peak as call_peak_pr1 { input :
-				peak_caller = peak_caller_,
-				peak_type = peak_type_,
-				ta = spr.ta_pr1,
-				gensz = gensz_,
-				chrsz = chrsz_,
-				cap_num_peak = cap_num_peak_,
-				pval_thresh = pval_thresh,
-				smooth_win = smooth_win,
-				blacklist = blacklist_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-				cpu = call_peak_cpu,
-				mem_mb = call_peak_mem_mb,
-				disks = call_peak_disks,
-				time_hr = call_peak_time_hr,
-			}
-		}
-		File? peak_pr1_ = if has_output_of_call_peak_pr1 then peaks_pr1[i]
-			else call_peak_pr1.peak
-
-		Boolean has_input_of_call_peak_pr2 = defined(spr.ta_pr2)
-		Boolean has_output_of_call_peak_pr2 = i<length(peaks_pr2) && defined(peaks_pr2[i])
-		if ( has_input_of_call_peak_pr2 && !has_output_of_call_peak_pr2 &&
-			!align_only && !true_rep_only ) {
-			# call peaks on 2nd pseudo replicated tagalign 
-			call call_peak as call_peak_pr2 { input :
-				peak_caller = peak_caller_,
-				peak_type = peak_type_,
-				ta = spr.ta_pr2,
-				gensz = gensz_,
-				chrsz = chrsz_,
-				cap_num_peak = cap_num_peak_,
-				pval_thresh = pval_thresh,
-				smooth_win = smooth_win,
-				blacklist = blacklist_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-				cpu = call_peak_cpu,
-				mem_mb = call_peak_mem_mb,
-				disks = call_peak_disks,
-				time_hr = call_peak_time_hr,
-			}
-		}
-		File? peak_pr2_ = if has_output_of_call_peak_pr2 then peaks_pr2[i]
-			else call_peak_pr2.peak
-
-		Boolean has_input_of_count_signal_track = has_output_of_bam2ta || defined(bam2ta.ta)
-		if ( has_input_of_count_signal_track && enable_count_signal_track ) {
-			# generate count signal track
-			call count_signal_track { input :
-				ta = ta_,
-				chrsz = chrsz_,
-			}
-		}
-		# tasks factored out from ATAqC
-		Boolean has_input_of_tss_enrich = defined(nodup_bam_) && defined(tss_) && (
-			defined(align.read_len) || i<length(read_len) && defined(read_len[i]) )
-		if ( enable_tss_enrich && has_input_of_tss_enrich ) {
-			call tss_enrich { input :
-				read_len = if i<length(read_len) && defined(read_len[i]) then read_len[i]
-					else align.read_len,
-				nodup_bam = nodup_bam_,
-				tss = tss_,
-				chrsz = chrsz_,
-			}
-		}
-		if ( enable_fraglen_stat && paired_end_ && defined(nodup_bam_) ) {
-			call fraglen_stat_pe { input :
-				nodup_bam = nodup_bam_,
-				picard_java_heap = fraglen_stat_picard_java_heap,				
-			}
-		}
-		if ( enable_preseq && defined(bam_) ) {
-			call preseq { input :
-				bam = bam_,
-				paired_end = paired_end_,
-				mem_mb = preseq_mem_mb,
-				picard_java_heap = preseq_picard_java_heap,
-			}
-		}
-		if ( enable_gc_bias && defined(nodup_bam_) && defined(ref_fa_) ) {
-			call gc_bias { input :
-				nodup_bam = nodup_bam_,
-				ref_fa = ref_fa_,
-				picard_java_heap = gc_bias_picard_java_heap,
-			}
-		}
-		if ( enable_annot_enrich && defined(ta_) && defined(blacklist_) && defined(dnase_) && defined(prom_) && defined(enh_) ) {
-			call annot_enrich { input :
-				ta = ta_,
-				blacklist = blacklist_,
-				dnase = dnase_,
-				prom = prom_,
-				enh = enh_,
-			}
-		}
-		if ( enable_compare_to_roadmap && defined(macs2_signal_track.pval_bw) &&
-			 defined(reg2map_) && defined(roadmap_meta_) &&
-			 ( defined(reg2map_bed_) || defined(dnase_) ) ) {
-			call compare_signal_to_roadmap { input :
-				pval_bw = macs2_signal_track.pval_bw,
-				dnase = dnase_,
-				reg2map_bed = reg2map_bed_,
-				reg2map = reg2map_,
-				roadmap_meta = roadmap_meta_,
-			}
-		}
-	}
-
-	# if there are TAs for ALL replicates then pool them
-	Boolean has_all_inputs_of_pool_ta = length(select_all(ta_))==num_rep
-	if ( has_all_inputs_of_pool_ta && num_rep>1 ) {
-		# pool tagaligns from true replicates
-		call pool_ta { input :
-			tas = ta_,
-			prefix = 'rep',			
-		}
-	}
-
-	# if there are pr1 TAs for ALL replicates then pool them
-	Boolean has_all_inputs_of_pool_ta_pr1 = length(select_all(spr.ta_pr1))==num_rep
-	if ( has_all_inputs_of_pool_ta_pr1 && num_rep>1 && !align_only && !true_rep_only ) {
-		# pool tagaligns from pseudo replicate 1
-		call pool_ta as pool_ta_pr1 { input :
-			tas = spr.ta_pr1,
-			prefix = 'rep-pr1',
-		}
-	}
-
-	# if there are pr2 TAs for ALL replicates then pool them
-	Boolean has_all_inputs_of_pool_ta_pr2 = length(select_all(spr.ta_pr2))==num_rep
-	if ( has_all_inputs_of_pool_ta_pr1 && num_rep>1 && !align_only && !true_rep_only ) {
-		# pool tagaligns from pseudo replicate 2
-		call pool_ta as pool_ta_pr2 { input :
-			tas = spr.ta_pr2,
-			prefix = 'rep-pr2',
-		}
-	}
-
-	Boolean has_input_of_call_peak_pooled = defined(pool_ta.ta_pooled)
-	Boolean has_output_of_call_peak_pooled = defined(peak_pooled)
-	if ( has_input_of_call_peak_pooled && !has_output_of_call_peak_pooled &&
-		!align_only && num_rep>1 ) {
-		# call peaks on pooled replicate
-		call call_peak as call_peak_pooled { input :
-			peak_caller = peak_caller_,
-			peak_type = peak_type_,
-			ta = pool_ta.ta_pooled,
-			gensz = gensz_,
-			chrsz = chrsz_,
-			cap_num_peak = cap_num_peak_,
-			pval_thresh = pval_thresh,
-			smooth_win = smooth_win,
-			blacklist = blacklist_,
-			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-			cpu = call_peak_cpu,
-			mem_mb = call_peak_mem_mb,
-			disks = call_peak_disks,
-			time_hr = call_peak_time_hr,
-		}
-	}
-	File? peak_pooled_ = if has_output_of_call_peak_pooled then peak_pooled
-		else call_peak_pooled.peak
-
-	Boolean has_input_of_count_signal_track_pooled = defined(pool_ta.ta_pooled)
-	if ( has_input_of_count_signal_track_pooled && enable_count_signal_track && num_rep>1 ) {
-		call count_signal_track as count_signal_track_pooled { input :
-			ta = pool_ta.ta_pooled,
-			chrsz = chrsz_,
-		}
-	}
-
-	Boolean has_input_of_macs2_signal_track_pooled = defined(pool_ta.ta_pooled)
-	if ( has_input_of_macs2_signal_track_pooled && num_rep>1 ) {
-		call macs2_signal_track as macs2_signal_track_pooled { input :
-			ta = pool_ta.ta_pooled,
-			gensz = gensz_,
-			chrsz = chrsz_,
-			pval_thresh = pval_thresh,
-			smooth_win = smooth_win,
-
-			mem_mb = macs2_signal_track_mem_mb,
-			disks = macs2_signal_track_disks,
-			time_hr = macs2_signal_track_time_hr,
-		}
-	}
-
-	Boolean has_input_of_jsd = defined(blacklist_) &&
-		length(select_all(nodup_bam_))==num_rep
-	if ( has_input_of_jsd && num_rep > 0 && enable_jsd ) {
-		# fingerprint and JS-distance plot
-		call jsd { input :
-			nodup_bams = nodup_bam_,
-			blacklist = blacklist_,
-			mapq_thresh = mapq_thresh_,
-
-			cpu = jsd_cpu,
-			mem_mb = jsd_mem_mb,
-			time_hr = jsd_time_hr,
-			disks = jsd_disks,
-		}
-	}
-
-	Boolean has_input_of_call_peak_ppr1 = defined(pool_ta_pr1.ta_pooled)
-	Boolean has_output_of_call_peak_ppr1 = defined(peak_ppr1)
-	if ( has_input_of_call_peak_ppr1 && !has_output_of_call_peak_ppr1 &&
-		!align_only && !true_rep_only && num_rep>1 ) {
-		# call peaks on 1st pooled pseudo replicates
-		call call_peak as call_peak_ppr1 { input :
-			peak_caller = peak_caller_,
-			peak_type = peak_type_,
-			ta = pool_ta_pr1.ta_pooled,
-			gensz = gensz_,
-			chrsz = chrsz_,
-			cap_num_peak = cap_num_peak_,
-			pval_thresh = pval_thresh,
-			smooth_win = smooth_win,
-			blacklist = blacklist_,
-			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-			cpu = call_peak_cpu,
-			mem_mb = call_peak_mem_mb,
-			disks = call_peak_disks,
-			time_hr = call_peak_time_hr,
-		}
-	}
-	File? peak_ppr1_ = if has_output_of_call_peak_ppr1 then peak_ppr1
-		else call_peak_ppr1.peak
-
-	Boolean has_input_of_call_peak_ppr2 = defined(pool_ta_pr2.ta_pooled)
-	Boolean has_output_of_call_peak_ppr2 = defined(peak_ppr2)
-	if ( has_input_of_call_peak_ppr2 && !has_output_of_call_peak_ppr2 &&
-		!align_only && !true_rep_only && num_rep>1 ) {
-		# call peaks on 2nd pooled pseudo replicates
-		call call_peak as call_peak_ppr2 { input :
-			peak_caller = peak_caller_,
-			peak_type = peak_type_,
-			ta = pool_ta_pr2.ta_pooled,
-			gensz = gensz_,
-			chrsz = chrsz_,
-			cap_num_peak = cap_num_peak_,
-			pval_thresh = pval_thresh,
-			smooth_win = smooth_win,
-			blacklist = blacklist_,
-			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-
-			cpu = call_peak_cpu,
-			mem_mb = call_peak_mem_mb,
-			disks = call_peak_disks,
-			time_hr = call_peak_time_hr,
-		}
-	}
-	File? peak_ppr2_ = if has_output_of_call_peak_ppr2 then peak_ppr2
-		else call_peak_ppr2.peak
-
-	# do IDR/overlap on all pairs of two replicates (i,j)
-	#	where i and j are zero-based indices and 0 <= i < j < num_rep
-	scatter( pair in cross(range(num_rep),range(num_rep)) ) {
-		File? peak1_ = peak_[pair.left]
-		File? peak2_ = peak_[pair.right]
-		if ( !align_only && pair.left<pair.right ) {
-			# pair.left = 0-based index of 1st replicate
-			# pair.right = 0-based index of 2nd replicate
-			# Naive overlap on every pair of true replicates
-			call overlap { input :
-				prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
-				peak1 = peak1_,
-				peak2 = peak2_,
-				peak_pooled = peak_pooled_,
-				peak_type = peak_type_,
-				blacklist = blacklist_,
-				chrsz = chrsz_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-				ta = pool_ta.ta_pooled,
-			}
-		}
-		if ( enable_idr && !align_only && pair.left<pair.right ) {
-			# pair.left = 0-based index of 1st replicate
-			# pair.right = 0-based index of 2nd replicate
-			# IDR on every pair of true replicates
-			call idr { input :
-				prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
-				peak1 = peak1_,
-				peak2 = peak2_,
-				peak_pooled = peak_pooled_,
-				idr_thresh = idr_thresh,
-				peak_type = peak_type_,
-				rank = idr_rank_,
-				blacklist = blacklist_,
-				chrsz = chrsz_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-				ta = pool_ta.ta_pooled,
-			}
-		}
-	}
-
-	# overlap on pseudo-replicates (pr1, pr2) for each true replicate
-	if ( !align_only && !true_rep_only ) {
-		scatter( i in range(num_rep) ) {
-			call overlap as overlap_pr { input :
-				prefix = 'rep'+(i+1)+'-pr1_vs_rep'+(i+1)+'-pr2',
-				peak1 = peak_pr1_[i],
-				peak2 = peak_pr2_[i],
-				peak_pooled = peak_[i],
-				peak_type = peak_type_,
-				blacklist = blacklist_,
-				chrsz = chrsz_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-				ta = ta_[i],
-			}
-		}
-	}
-
-	if ( !align_only && !true_rep_only && enable_idr ) {
-		scatter( i in range(num_rep) ) {
-			# IDR on pseduo replicates
-			call idr as idr_pr { input :
-				prefix = 'rep'+(i+1)+'-pr1_vs_rep'+(i+1)+'-pr2',
-				peak1 = peak_pr1_[i],
-				peak2 = peak_pr2_[i],
-				peak_pooled = peak_[i],
-				idr_thresh = idr_thresh,
-				peak_type = peak_type_,
-				rank = idr_rank_,
-				blacklist = blacklist_,
-				chrsz = chrsz_,
-				regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-				ta = ta_[i],
-			}
-		}
-	}
-
-	if ( !align_only && !true_rep_only && num_rep>1 ) {
-		# Naive overlap on pooled pseudo replicates
-		call overlap as overlap_ppr { input :
-			prefix = 'pooled-pr1_vs_pooled-pr2',
-			peak1 = peak_ppr1_,
-			peak2 = peak_ppr2_,
-			peak_pooled = peak_pooled_,
-			peak_type = peak_type_,
-			blacklist = blacklist_,
-			chrsz = chrsz_,
-			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-			ta = pool_ta.ta_pooled,
-		}
-	}
-
-	if ( !align_only && !true_rep_only && num_rep>1 ) {
-		# IDR on pooled pseduo replicates
-		call idr as idr_ppr { input :
-			prefix = 'pooled-pr1_vs_pooled-pr2',
-			peak1 = peak_ppr1_,
-			peak2 = peak_ppr2_,
-			peak_pooled = peak_pooled_,
-			idr_thresh = idr_thresh,
-			peak_type = peak_type_,
-			rank = idr_rank_,
-			blacklist = blacklist_,
-			chrsz = chrsz_,
-			regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
-			ta = pool_ta.ta_pooled,
-		}
-	}
-
-	# reproducibility QC for overlap/IDR peaks
-	if ( !align_only && !true_rep_only && num_rep > 0 ) {
-		# reproducibility QC for overlapping peaks
-		call reproducibility as reproducibility_overlap { input :
-			prefix = 'overlap',
-			peaks = select_all(overlap.bfilt_overlap_peak),
-			peaks_pr = overlap_pr.bfilt_overlap_peak,
-			peak_ppr = overlap_ppr.bfilt_overlap_peak,
-			peak_type = peak_type_,
-			chrsz = chrsz_,
-		}
-	}
-
-	if ( !align_only && !true_rep_only && num_rep > 0 && enable_idr ) {
-		# reproducibility QC for IDR peaks
-		call reproducibility as reproducibility_idr { input :
-			prefix = 'idr',
-			peaks = select_all(idr.bfilt_idr_peak),
-			peaks_pr = idr_pr.bfilt_idr_peak,
-			peak_ppr = idr_ppr.bfilt_idr_peak,
-			peak_type = peak_type_,
-			chrsz = chrsz_,
-		}
-	}
-
-	# Generate final QC report and JSON
-	call qc_report { input :
-		pipeline_ver = pipeline_ver,
-		title = title,
-		description = description,
-		genome = genome_name_,
-		multimapping = multimapping,
-		paired_ends = paired_end_,
-		pipeline_type = pipeline_type,
-		aligner = aligner_,
-		peak_caller = peak_caller_,
-		cap_num_peak = cap_num_peak_,
-		idr_thresh = idr_thresh,
-		pval_thresh = pval_thresh,
-		xcor_subsample_reads = xcor_subsample_reads,
-
-		samstat_qcs = select_all(align.samstat_qc),
-		nodup_samstat_qcs = select_all(filter.samstat_qc),
-
-		frac_mito_qcs = select_all(frac_mito.frac_mito_qc),
-		dup_qcs = select_all(filter.dup_qc),
-		lib_complexity_qcs = select_all(filter.lib_complexity_qc),
-		xcor_plots = select_all(xcor.plot_png),
-		xcor_scores = select_all(xcor.score),
-
-		jsd_plot = jsd.plot,
-		jsd_qcs = jsd.jsd_qcs,
-
-		frip_qcs = select_all(call_peak.frip_qc),
-		frip_qcs_pr1 = select_all(call_peak_pr1.frip_qc),
-		frip_qcs_pr2 = select_all(call_peak_pr2.frip_qc),
-
-		frip_qc_pooled = call_peak_pooled.frip_qc,
-		frip_qc_ppr1 = call_peak_ppr1.frip_qc,
-		frip_qc_ppr2 = call_peak_ppr2.frip_qc,
-
-		idr_plots = select_all(idr.idr_plot),
-		idr_plots_pr = idr_pr.idr_plot,
-		idr_plot_ppr = idr_ppr.idr_plot,
-		frip_idr_qcs = select_all(idr.frip_qc),
-		frip_idr_qcs_pr = idr_pr.frip_qc,
-		frip_idr_qc_ppr = idr_ppr.frip_qc,
-		frip_overlap_qcs = select_all(overlap.frip_qc),
-		frip_overlap_qcs_pr = overlap_pr.frip_qc,
-		frip_overlap_qc_ppr = overlap_ppr.frip_qc,
-		idr_reproducibility_qc = reproducibility_idr.reproducibility_qc,
-		overlap_reproducibility_qc = reproducibility_overlap.reproducibility_qc,
-
-		annot_enrich_qcs = select_all(annot_enrich.annot_enrich_qc),
-		tss_enrich_qcs = select_all(tss_enrich.tss_enrich_qc),
-		tss_large_plots = select_all(tss_enrich.tss_large_plot),
-		roadmap_compare_plots = select_all(compare_signal_to_roadmap.roadmap_compare_plot),
-		fraglen_dist_plots = select_all(fraglen_stat_pe.fraglen_dist_plot),
-		fraglen_nucleosomal_qcs = select_all(fraglen_stat_pe.nucleosomal_qc),
-		gc_plots = select_all(gc_bias.gc_plot),
-		preseq_plots = select_all(preseq.preseq_plot),
-		picard_est_lib_size_qcs = select_all(preseq.picard_est_lib_size_qc),
-
-		peak_region_size_qcs = select_all(call_peak.peak_region_size_qc),
-		peak_region_size_plots = select_all(call_peak.peak_region_size_plot),
-		num_peak_qcs = select_all(call_peak.num_peak_qc),
-
-		idr_opt_peak_region_size_qc = reproducibility_idr.peak_region_size_qc,
-		idr_opt_peak_region_size_plot = reproducibility_overlap.peak_region_size_plot,
-		idr_opt_num_peak_qc = reproducibility_idr.num_peak_qc,
-
-		overlap_opt_peak_region_size_qc = reproducibility_overlap.peak_region_size_qc,
-		overlap_opt_peak_region_size_plot = reproducibility_overlap.peak_region_size_plot,
-		overlap_opt_num_peak_qc = reproducibility_overlap.num_peak_qc,
-	}
-
-	output {
-		File report = qc_report.report
-		File qc_json = qc_report.qc_json
-		Boolean qc_json_ref_match = qc_report.qc_json_ref_match
-	}
+    String pipeline_ver = 'v1.7.1'
+
+    meta {
+        author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
+        description: 'ATAC-Seq/DNase-Seq pipeline'
+        specification_document: 'https://docs.google.com/document/d/1f0Cm4vRyDQDu0bMehHD7P7KOMxTOP-HiNoIvL1VcBt8/edit?usp=sharing'
+
+        caper_docker: 'quay.io/encode-dcc/atac-seq-pipeline:v1.7.1'
+        caper_singularity: 'docker://quay.io/encode-dcc/atac-seq-pipeline:v1.7.1'
+        croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/atac.croo.v4.json'
+    }
+    input {
+        # group: pipeline_metadata
+        String title = 'Untitled'
+        String description = 'No description'
+
+        # group: reference_genome
+        File? genome_tsv
+        String? genome_name
+        File? ref_fa
+        File? ref_mito_fa
+        File? bowtie2_idx_tar
+        File? bowtie2_mito_idx_tar
+        File? chrsz
+        File? blacklist
+        File? blacklist2
+        String? mito_chr_name
+        String? regex_bfilt_peak_chr_name
+        String? gensz
+        File? tss
+        File? dnase
+        File? prom
+        File? enh
+        File? reg2map
+        File? reg2map_bed
+        File? roadmap_meta
+
+        # group: input_genomic_data
+        Boolean? paired_end
+        Array[Boolean] paired_ends = []
+        Array[File] fastqs_rep1_R1 = []
+        Array[File] fastqs_rep1_R2 = []
+        Array[File] fastqs_rep2_R1 = []
+        Array[File] fastqs_rep2_R2 = []
+        Array[File] fastqs_rep3_R1 = []
+        Array[File] fastqs_rep3_R2 = []
+        Array[File] fastqs_rep4_R1 = []
+        Array[File] fastqs_rep4_R2 = []
+        Array[File] fastqs_rep5_R1 = []
+        Array[File] fastqs_rep5_R2 = []
+        Array[File] fastqs_rep6_R1 = []
+        Array[File] fastqs_rep6_R2 = []
+        Array[File] fastqs_rep7_R1 = []
+        Array[File] fastqs_rep7_R2 = []
+        Array[File] fastqs_rep8_R1 = []
+        Array[File] fastqs_rep8_R2 = []
+        Array[File] fastqs_rep9_R1 = []
+        Array[File] fastqs_rep9_R2 = []
+        Array[File] fastqs_rep10_R1 = []
+        Array[File] fastqs_rep10_R2 = []
+        Array[File?] bams = []
+        Array[File?] nodup_bams = []
+        Array[File?] tas = []
+        Array[File?] peaks = []
+        Array[File?] peaks_pr1 = []
+        Array[File?] peaks_pr2 = []
+        File? peak_pooled
+        File? peak_ppr1
+        File? peak_ppr2
+
+        # group: pipeline_parameter
+        String pipeline_type = 'atac'
+        Boolean align_only = false
+        Boolean true_rep_only = false
+        Boolean enable_xcor = false
+        Boolean enable_count_signal_track = false
+        Boolean enable_idr = true
+        Boolean enable_preseq = false
+        Boolean enable_fraglen_stat = true
+        Boolean enable_tss_enrich = true
+        Boolean enable_annot_enrich = true
+        Boolean enable_jsd = true
+        Boolean enable_compare_to_roadmap = false
+        Boolean enable_gc_bias = true
+
+        # group: adapter_trimming
+        String cutadapt_param = '-e 0.1 -m 5'
+        Boolean auto_detect_adapter = false
+        String? adapter
+        Array[String] adapters_rep1_R1 = []
+        Array[String] adapters_rep1_R2 = []
+        Array[String] adapters_rep2_R1 = []
+        Array[String] adapters_rep2_R2 = []
+        Array[String] adapters_rep3_R1 = []
+        Array[String] adapters_rep3_R2 = []
+        Array[String] adapters_rep4_R1 = []
+        Array[String] adapters_rep4_R2 = []
+        Array[String] adapters_rep5_R1 = []
+        Array[String] adapters_rep5_R2 = []
+        Array[String] adapters_rep6_R1 = []
+        Array[String] adapters_rep6_R2 = []
+        Array[String] adapters_rep7_R1 = []
+        Array[String] adapters_rep7_R2 = []
+        Array[String] adapters_rep8_R1 = []
+        Array[String] adapters_rep8_R2 = []
+        Array[String] adapters_rep9_R1 = []
+        Array[String] adapters_rep9_R2 = []
+        Array[String] adapters_rep10_R1 = []
+        Array[String] adapters_rep10_R2 = []
+
+        # group: alignment
+        Int multimapping = 4
+        String dup_marker = 'picard'
+        Boolean no_dup_removal = false
+        Int mapq_thresh = 30
+        Array[String] filter_chrs = ['chrM', 'MT']
+        Int subsample_reads = 0
+        Int xcor_subsample_reads = 25000000
+        Array[Int?] read_len = []
+
+        # group: peak_calling
+        Int cap_num_peak = 300000
+        Float pval_thresh = 0.01
+        Int smooth_win = 150
+        Float idr_thresh = 0.05
+
+        # group: resource_parameter
+        Int align_cpu = 4
+        Int align_mem_mb = 20000
+        Int align_time_hr = 48
+        String align_disks = 'local-disk 400 HDD'
+
+        Int filter_cpu = 2
+        Int filter_mem_mb = 20000
+        Int filter_time_hr = 24
+        String filter_disks = 'local-disk 400 HDD'
+
+        Int bam2ta_cpu = 2
+        Int bam2ta_mem_mb = 10000
+        Int bam2ta_time_hr = 6
+        String bam2ta_disks = 'local-disk 100 HDD'
+
+        Int spr_mem_mb = 16000
+
+        Int jsd_cpu = 2
+        Int jsd_mem_mb = 12000
+        Int jsd_time_hr = 6
+        String jsd_disks = 'local-disk 200 HDD'
+
+        Int xcor_cpu = 2
+        Int xcor_mem_mb = 16000
+        Int xcor_time_hr = 6
+        String xcor_disks = 'local-disk 100 HDD'
+
+        Int call_peak_cpu = 1
+        Int call_peak_mem_mb = 16000
+        Int call_peak_time_hr = 24
+        String call_peak_disks = 'local-disk 200 HDD'
+
+        Int macs2_signal_track_mem_mb = 16000
+        Int macs2_signal_track_time_hr = 24
+        String macs2_signal_track_disks = 'local-disk 400 HDD'
+
+        Int preseq_mem_mb = 16000
+
+        String? filter_picard_java_heap
+        String? preseq_picard_java_heap
+        String? fraglen_stat_picard_java_heap
+        String? gc_bias_picard_java_heap
+    }
+
+    parameter_meta {
+        title: {
+            description: 'Experiment title.',
+            group: 'pipeline_metadata',
+        }
+        description: {
+            description: 'Experiment description.',
+            group: 'pipeline_metadata',
+        }
+        genome_tsv: {
+            description: 'Reference genome database TSV.',
+            group: 'reference_genome',
+            help: 'This TSV files includes all genome specific parameters (e.g. reference FASTA, bowtie2 index). You can still invidiaully define any parameters in it. Parameters defined in input JSON will override those defined in genome TSV.'
+        }
+        genome_name: {
+            description: 'Genome name.',
+            group: 'reference_genome'
+        }
+        ref_fa: {
+            description: 'Reference FASTA file.',
+            group: 'reference_genome'
+        }
+        ref_mito_fa: {
+            description: 'Reference FASTA file (mitochondrial reads only).',
+            group: 'reference_genome'
+        }
+        bowtie2_idx_tar: {
+            description: 'BWA index TAR file.',
+            group: 'reference_genome'
+        }
+        bowtie2_mito_idx_tar: {
+            description: 'BWA index TAR file (mitochondrial reads only).',
+            group: 'reference_genome'
+        }
+        chrsz: {
+            description: '2-col chromosome sizes file.',
+            group: 'reference_genome'
+        }
+        blacklist: {
+            description: 'Blacklist file in BED format.',
+            group: 'reference_genome',
+            help: 'Peaks will be filtered with this file.'
+        }
+        blacklist2: {
+            description: 'Secondary blacklist file in BED format.',
+            group: 'reference_genome',
+            help: 'If it is defined, it will be merged with atac.blacklist. Peaks will be filtered with merged blacklist.'
+        }
+        mito_chr_name: {
+            description: 'Mitochondrial chromosome name.',
+            group: 'reference_genome',
+            help: 'e.g. chrM, MT. Mitochondrial reads defined here will be filtered out during filtering BAMs in "filter" task.'
+        }
+        regex_bfilt_peak_chr_name: {
+            description: 'Reg-ex for chromosomes to keep while filtering peaks.',
+            group: 'reference_genome',
+            help: 'Chromosomes defined here will be kept. All other chromosomes will be filtered out in .bfilt. peak file. This is done along with blacklist filtering peak file.'
+        }
+        gensz: {
+            description: 'Genome sizes. "hs" for human, "mm" for mouse or sum of 2nd columnin chromosome sizes file.',
+            group: 'reference_genome'
+        }
+        tss: {
+            description: 'TSS file in BED format.',
+            group: 'reference_genome'
+        }
+        dnase: {
+            description: 'Open chromatin regions file in BED format.',
+            group: 'reference_genome'
+        }
+        prom: {
+            description: 'Promoter regions file in BED format.',
+            group: 'reference_genome'
+        }
+        enh: {
+            description: 'Enhancer regions file in BED format.',
+            group: 'reference_genome'
+        }
+        reg2map: {
+            description: 'Cell type signals file.',
+            group: 'reference_genome'
+        }
+        reg2map_bed: {
+            description: 'File of regions used to generate reg2map signals.',
+            group: 'reference_genome'
+        }
+        roadmap_meta: {
+            description: 'Roadmap metadata.',
+            group: 'reference_genome'
+        }
+        paired_end: {
+            description: 'Sequencing endedness.',
+            group: 'input_genomic_data',
+            help: 'Setting this on means that all replicates are paired ended. For mixed samples, use atac.paired_ends array instead.'
+        }
+        paired_ends: {
+            description: 'Sequencing endedness array (for mixed SE/PE datasets).',
+            group: 'input_genomic_data',
+            help: 'Whether each biological replicate is paired ended or not.'
+        }
+        fastqs_rep1_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of inputs (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined. Especially for FASTQs, we have individual variable for each biological replicate to allow FASTQs of technical replicates can be merged. Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep1_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep1_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep2_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 2.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep2_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 2.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep3_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 3.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep3_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 3.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep4_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 4.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep4_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 4.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep5_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 5.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep5_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 5.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep6_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 6.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep6_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 6.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep7_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 7.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep7_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep7_R2: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 7.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep7_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep8_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 8.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep8_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep8_R2: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 8.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep8_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep9_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 9.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep9_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep9_R2: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 9.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep9_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep10_R1: {
+            description: 'Read1 FASTQs to be merged for a biological replicate 10.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep10_R2). These FASTQs are usually technical replicates to be merged.'
+        }
+        fastqs_rep10_R2: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 10.',
+            group: 'input_genomic_data',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep10_R1). These FASTQs are usually technical replicates to be merged.'
+        }
+        bams: {
+            description: 'List of unfiltered/raw BAM files for each biological replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from BAM files. Unfiltered/raw BAM file generated from aligner (e.g. bowtie2). Each entry for each biological replicate. e.g. [rep1.bam, rep2.bam, rep3.bam, ...].'
+        }
+        nodup_bams: {
+            description: 'List of filtered/deduped BAM files for each biological replicate',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from filtered BAM files. Filtered/deduped BAM file. Each entry for each biological replicate. e.g. [rep1.nodup.bam, rep2.nodup.bam, rep3.nodup.bam, ...].'
+        }
+        tas: {
+            description: 'List of TAG-ALIGN files for each biological replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from TAG-ALIGN files. TAG-ALIGN is in a 6-col BED format. It is a simplified version of BAM. Each entry for each biological replicate. e.g. [rep1.tagAlign.gz, rep2.tagAlign.gz, ...].'
+        }
+        peaks: {
+            description: 'List of NARROWPEAK files (not blacklist filtered) for each biological replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Each entry for each biological replicate. e.g. [rep1.narrowPeak.gz, rep2.narrowPeak.gz, ...]. Define other PEAK parameters (e.g. atac.peaks_pr1, atac.peak_pooled) according to your flag settings (e.g. atac.true_rep_only) and number of replicates. If you have more than one replicate then define atac.peak_pooled, atac.peak_ppr1 and atac.peak_ppr2. If atac.true_rep_only flag is on then do not define any parameters (atac.peaks_pr1, atac.peaks_pr2, atac.peak_ppr1 and atac.peak_ppr2) related to pseudo replicates.'
+        }
+        peaks_pr1: {
+            description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 1 of each biological replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Define if atac.true_rep_only flag is off.'
+        }
+        peaks_pr2: {
+            description: 'List of NARROWPEAK files (not blacklist filtered) for pseudo-replicate 2 of each biological replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Define if atac.true_rep_only flag is off.'
+        }
+        peak_pooled: {
+            description: 'NARROWPEAK file for pooled true replicate.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates. Pooled true replicate means analysis on pooled biological replicates.'
+        }
+        peak_ppr1: {
+            description: 'NARROWPEAK file for pooled pseudo replicate 1.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and atac.truerep_only flag is off. PPR1 means analysis on pooled 1st pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 1st pseudos.'
+        }
+        peak_ppr2: {
+            description: 'NARROWPEAK file for pooled pseudo replicate 2.',
+            group: 'input_genomic_data',
+            help: 'Define if you want to start pipeline from PEAK files. Define if you have multiple biological replicates and atac.truerep_only flag is off. PPR1 means analysis on pooled 2nd pseudo replicates. Each biological replicate is shuf/split into two pseudos. This is a pooling of each replicate\'s 2nd pseudos.'
+        }
+
+        pipeline_type: {
+            description: 'Pipeline type. atac for ATAC-Seq or dnase for DNase-Seq.',
+            group: 'pipeline_parameter',
+            help: 'The only difference of two types is that TN5 shifting of TAG-ALIGN is done for atac. TAG-ALIGN is in 6-col BED format. It is a simplified version of BAM.'
+        }
+        align_only: {
+            description: 'Align only mode.',
+            group: 'pipeline_parameter',
+            help: 'Reads will be aligned but there will be no peak-calling on them.'
+        }
+        true_rep_only: {
+            description: 'Disables all analyses related to pseudo-replicates.',
+            group: 'pipeline_parameter',
+            help: 'Pipeline generates 2 pseudo-replicate from one biological replicate. This flag turns off all analyses related to pseudos (with prefix/suffix pr, ppr).'
+        }
+        enable_xcor: {
+            description: 'Enables cross-correlation analysis.',
+            group: 'pipeline_parameter',
+            help: 'Generates cross-correlation plot.'
+        }
+        enable_count_signal_track: {
+            description: 'Enables generation of count signal tracks.',
+            group: 'pipeline_parameter'
+        }
+        enable_idr: {
+            description: 'Enables IDR on MACS2 NARROWPEAKs.',
+            group: 'pipeline_parameter'
+        }
+        enable_preseq: {
+            description: 'Enables preseq analysis.',
+            group: 'pipeline_parameter'
+        }
+        enable_fraglen_stat: {
+            description: 'Enables calculation of fragment length distribution/statistics.',
+            group: 'pipeline_parameter'
+        }
+        enable_tss_enrich: {
+            description: 'Enables TSS enrichment plot generation.',
+            group: 'pipeline_parameter'
+        }
+        enable_tss_enrich: {
+            description: 'Enables annotation enrichment analysis.',
+            group: 'pipeline_parameter'
+        }
+        enable_jsd: {
+            description: 'Enables Jensen-Shannon Distance (JSD) plot generation.',
+            group: 'pipeline_parameter'
+        }
+        enable_compare_to_roadmap: {
+            description: 'Enables comparison to Roadmap.',
+            group: 'pipeline_parameter'
+        }
+        enable_gc_bias: {
+            description: 'Enables GC bias calculation.',
+            group: 'pipeline_parameter'
+        }
+
+        cutadapt_param: {
+            description: 'Parameters for cutadapt.',
+            group: 'adapter_trimming',
+            help: 'It is -e 0.1 -m 5 by default (err_rate=0.1, min_trim_len=5). You can define any parameters that cutadapt supports.'
+        }
+        auto_detect_adapter: {
+            description: 'Auto-detect/trim adapter sequences.',
+            group: 'adapter_trimming',
+            help: 'Can detect three types of adapter sequences. Illumina: AGATCGGAAGAGC, Nextera: CTGTCTCTTATA, smallRNA: TGGAATTCTCGG.'
+        }
+        adapter: {
+            description: 'Adapter for all FASTQs.',
+            group: 'adapter_trimming',
+            help: 'Define if all FASTQs have the same adapter sequence. Otherwise define adapter sequence for individual FASTQ in atac.adapters_repX_R1 and atac.adapters_repX_R2 instead. Use atac.auto_detect_adapter if you want to detect adapters automatically.'
+        }
+        adapters_rep1_R1: {
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep1_R2). You can combine this with atac.auto_detect_adapter. Pipeline will auto-detect/trim adapter sequences for null entry in this list. e.g. ["AAGGCCTT", null, "AAGGCCTT"].'
+        }
+        adapters_rep1_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep1_R1).'
+        }
+        adapters_rep2_R1: {
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep2_R2).'
+        }
+        adapters_rep2_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep2_R1).'
+        }
+        adapters_rep3_R1: {
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep3_R2).'
+        }
+        adapters_rep3_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep3_R1).'
+        }
+        adapters_rep4_R1: {
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep4_R2).'
+        }
+        adapters_rep4_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep4_R1).'
+        }
+        adapters_rep5_R1: {
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep5_R2).'
+        }
+        adapters_rep5_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep5_R1).'
+        }
+        adapters_rep6_R1: {
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep6_R2).'
+        }
+        adapters_rep6_R1: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep6_R1).'
+        }
+        adapters_rep7_R1: {
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep7_R2).'
+        }
+        adapters_rep7_R2: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep7_R1).'
+        }
+        adapters_rep8_R1: {
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep8_R2).'
+        }
+        adapters_rep8_R2: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep8_R1).'
+        }
+        adapters_rep9_R1: {
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep9_R2).'
+        }
+        adapters_rep9_R2: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep9_R1).'
+        }
+        adapters_rep10_R1: {
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep10_R2).'
+        }
+        adapters_rep10_R2: {
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            group: 'adapter_trimming',
+            help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep10_R1).'
+        }
+
+        multimapping: {
+            description: 'Number of multimappers.',
+            group: 'alignment',
+            help: 'It is 4 by default. Set it to 0 if your sample does not have multimappers.'
+        }
+        dup_marker: {
+            description: 'Marker for duplicate reads. picard or sambamba.',
+            group: 'alignment',
+            help: 'picard for Picard MarkDuplicates or sambamba for sambamba markdup.'
+        }
+        no_dup_removal: {
+            description: 'Disable removal of duplicate reads during filtering BAM.',
+            group: 'alignment',
+            help: 'Duplicate reads are filtererd out during filtering BAMs to gerenate NODUP_BAM. This flag will keep all duplicate reads in NODUP_BAM. This flag does not affect naming of NODUP_BAM. NODUP_BAM will still have .nodup. suffix in its filename.'
+        }
+        mapq_thresh: {
+            description: 'Threshold for low MAPQ reads removal',
+            group: 'alignment',
+            help: 'Low MAPQ reads are filtered out while filtering BAM.',
+        }
+        filter_chrs: {
+            description: 'List of chromosomes to be filtered out while filtering BAM.',
+            group: 'alignment',
+            help: 'It is ["chrM", "MT"] by default. Therefore, mitochondrial reads will be filtered out while filtering. Make it empty if you want to keep all reads.'
+        }
+        subsample_reads: {
+            description: 'Subsample reads. Shuffle and subsample reads.',
+            group: 'alignment',
+            help: 'This affects all downstream analyses after filtering BAM. (e.g. all TAG-ALIGN files, peak-calling). Reads will be shuffled only if actual number of reads in BAM exceeds this number.'
+        }
+        xcor_subsample_reads: {
+            description: 'Subsample reads for cross-corrlelation analysis only.',
+            group: 'alignment',
+            help: 'This does not affect downstream analyses after filtering BAM. It is for cross-correlation analysis only.'
+        }
+        read_len: {
+            description: 'Read length per biological replicate.',
+            group: 'alignment',
+            help: 'Pipeline can estimate read length from FASTQs. If you start pipeline from other types (BAM, NODUP_BAM, TA, ...) than FASTQ. Then provide this for some analyses that require read length (e.g. TSS enrichment plot).'
+        }
+
+        cap_num_peak: {
+            description: 'Upper limit on the number of peaks.',
+            group: 'peak_calling',
+            help: 'Called peaks will be sorted in descending order of score and the number of peaks will be capped at this number by taking first N peaks.'
+        }
+        pval_thresh: {
+            description: 'p-value Threshold for MACS2 peak caller.',
+            group: 'peak_calling',
+            help: 'macs2 callpeak -p'
+        }
+        smooth_win: {
+            description: 'Size of smoothing windows for MACS2 peak caller.',
+            group: 'peak_calling',
+            help: 'This will be used for both generating MACS2 peaks/signal tracks.'
+        }
+        idr_thresh: {
+            description: 'IDR threshold.',
+            group: 'peak_calling'
+        }
+
+        align_cpu: {
+            description: 'Number of cores for task align.',
+            group: 'resource_parameter',
+            help: 'Task align merges/crops/maps FASTQs.'
+        }
+        align_mem_mb: {
+            description: 'Memory (MB) required for task align.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        align_time_hr: {
+            description: 'Walltime (h) required for task align.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        align_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task align.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        filter_cpu: {
+            description: 'Number of cores for task filter.',
+            group: 'resource_parameter',
+            help: 'Task filter filters raw/unfilterd BAM to get filtered/deduped BAM.'
+        }
+        filter_mem_mb: {
+            description: 'Memory (MB) required for task filter.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        filter_time_hr: {
+            description: 'Walltime (h) required for task filter.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        filter_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task filter.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        bam2ta_cpu: {
+            description: 'Number of cores for task bam2ta.',
+            group: 'resource_parameter',
+            help: 'Task bam2ta converts filtered/deduped BAM in to TAG-ALIGN (6-col BED) format.'
+        }
+        bam2ta_mem_mb: {
+            description: 'Memory (MB) required for task bam2ta.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        bam2ta_time_hr: {
+            description: 'Walltime (h) required for task bam2ta.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        bam2ta_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task bam2ta.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        spr_mem_mb: {
+            description: 'Memory (MB) required for task spr.',
+            group: 'resource_parameter',
+            help: 'Task spr generates two pseudo-replicates from each biological replicate. This task uses Unix shuf/sort, which can take significant amount of memory.'
+        }
+        jsd_cpu: {
+            description: 'Number of cores for task jsd.',
+            group: 'resource_parameter',
+            help: 'Task jsd plots Jensen-Shannon distance and metrics related to it.'
+        }
+        jsd_mem_mb: {
+            description: 'Memory (MB) required for task jsd.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        jsd_time_hr: {
+            description: 'Walltime (h) required for task jsd.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        jsd_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task jsd.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        xcor_cpu: {
+            description: 'Number of cores for task xcor.',
+            group: 'resource_parameter',
+            help: 'Task xcor does cross-correlation analysis (including a plot) on subsampled TAG-ALIGNs.'
+        }
+        xcor_mem_mb: {
+            description: 'Memory (MB) required for task xcor.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        xcor_time_hr: {
+            description: 'Walltime (h) required for task xcor.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        xcor_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task xcor.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        call_peak_cpu: {
+            description: 'Number of cores for task call_peak.',
+            group: 'resource_parameter',
+            help: 'Task call_peak call peaks on TAG-ALIGNs by using MACS2 peak caller.'
+        }
+        call_peak_mem_mb: {
+            description: 'Memory (MB) required for task call_peak.',
+            group: 'resource_parameter',
+            help: 'This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        call_peak_time_hr: {
+            description: 'Walltime (h) required for task call_peak.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        call_peak_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task call_peak.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        macs2_signal_track_mem_mb: {
+            description: 'Memory (MB) required for task macs2_signal_track.',
+            group: 'resource_parameter',
+            help: 'Task macs2_signal_track_mem_mb uses MACS2 to get signal tracks for p-val (suffixed with .pval.) and fold enrichment (suffixed with .fc.). This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        macs2_signal_track_time_hr: {
+            description: 'Walltime (h) required for task macs2_signal_track.',
+            group: 'resource_parameter',
+            help: 'This is for HPCs only. e.g. SLURM, SGE, ...'
+        }
+        macs2_signal_track_disks: {
+            description: 'Persistent disk size to store intermediate files and outputs of task macs2_signal_track.',
+            group: 'resource_parameter',
+            help: 'This is for GCP/AWS only.'
+        }
+        preseq_mem_mb: {
+            description: 'Memory (MB) required for task preseq.',
+            group: 'resource_parameter',
+            help: 'Task preseq estimates the future yield of a genomic library. This will be used for determining instance type for GCP/AWS or job\'s maximum required memory for HPC.'
+        }
+        filter_picard_java_heap: {
+            description: 'Maximum Java heap (java -Xmx) in task filter.',
+            group: 'resource_parameter',
+            help: 'Maximum memory for Picard tools MarkDuplicates. If not defined, 90% of filter_mem_mb will be used.'
+        }
+        preseq_picard_java_heap: {
+            description: 'Maximum Java heap (java -Xmx) in task preseq.',
+            group: 'resource_parameter',
+            help: 'Maximum memory for Picard tools EstimateLibraryComplexity. If not defined, 90% of preseq_mem_mb will be used.'
+        }
+        fraglen_stat_picard_java_heap: {
+            description: 'Maximum Java heap (java -Xmx) in task fraglen_stat_pe (for paired end replicate only).',
+            group: 'resource_parameter',
+            help: 'Maximum memory for Picard tools CollectInsertSizeMetrics. If not defined, 90% of 8000 MB will be used.'
+        }
+        gc_bias_picard_java_heap: {
+            description: 'Maximum Java heap (java -Xmx) in task gc_bias.',
+            group: 'resource_parameter',
+            help: 'Maximum memory for Picard tools CollectGcBiasMetrics. If not defined, 90% of 10000 MB will be used.'
+        }
+    }
+
+    String aligner = 'bowtie2'
+    String peak_caller = 'macs2'
+    String peak_type = 'narrowPeak'
+    
+    # read genome data and paths
+    if ( defined(genome_tsv) ) {
+        call read_genome_tsv { input: genome_tsv = genome_tsv }
+    }
+    File ref_fa_ = select_first([ref_fa, read_genome_tsv.ref_fa])
+    File bowtie2_idx_tar_ = select_first([bowtie2_idx_tar, read_genome_tsv.bowtie2_idx_tar])
+    File bowtie2_mito_idx_tar_ = select_first([bowtie2_mito_idx_tar, read_genome_tsv.bowtie2_mito_idx_tar])
+    File chrsz_ = select_first([chrsz, read_genome_tsv.chrsz])
+    String gensz_ = select_first([gensz, read_genome_tsv.gensz])
+    File? blacklist1_ = if defined(blacklist) then blacklist
+        else read_genome_tsv.blacklist
+    File? blacklist2_ = if defined(blacklist2) then blacklist2
+        else read_genome_tsv.blacklist2        
+    # merge multiple blacklists
+    # two blacklists can have different number of columns (3 vs 6)
+    # so we limit merged blacklist's columns to 3
+    Array[File] blacklists = select_all([blacklist1_, blacklist2_])
+    if ( length(blacklists) > 1 ) {
+        call pool_ta as pool_blacklist { input:
+            tas = blacklists,
+            col = 3,
+        }
+    }
+    File? blacklist_ = if length(blacklists) > 1 then pool_blacklist.ta_pooled
+        else if length(blacklists) > 0 then blacklists[0]
+        else blacklist2_
+    String mito_chr_name_ = select_first([mito_chr_name, read_genome_tsv.mito_chr_name])
+    String regex_bfilt_peak_chr_name_ = select_first([regex_bfilt_peak_chr_name, read_genome_tsv.regex_bfilt_peak_chr_name])
+    String genome_name_ = select_first([genome_name, read_genome_tsv.genome_name, basename(chrsz_)])
+
+    # read additional annotation data
+    File? tss_ = if defined(tss) then tss
+        else read_genome_tsv.tss
+    File? dnase_ = if defined(dnase) then dnase
+        else read_genome_tsv.dnase
+    File? prom_ = if defined(prom) then prom
+        else read_genome_tsv.prom
+    File? enh_ = if defined(enh) then enh
+        else read_genome_tsv.enh
+    File? reg2map_ = if defined(reg2map) then reg2map
+        else read_genome_tsv.reg2map
+    File? reg2map_bed_ = if defined(reg2map_bed) then reg2map_bed
+        else read_genome_tsv.reg2map_bed
+    File? roadmap_meta_ = if defined(roadmap_meta) then roadmap_meta
+        else read_genome_tsv.roadmap_meta
+
+    ### temp vars (do not define these)
+    String aligner_ = aligner
+    String peak_caller_ = peak_caller
+    String peak_type_ = peak_type
+    String idr_rank_ = if peak_caller_=='spp' then 'signal.value'
+                        else if peak_caller_=='macs2' then 'p.value'
+                        else 'p.value'
+    Int cap_num_peak_ = cap_num_peak
+    Int mapq_thresh_ = mapq_thresh
+
+    # temporary 2-dim fastqs array [rep_id][merge_id]
+    Array[Array[File]] fastqs_R1 = 
+        if length(fastqs_rep10_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
+            fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1, fastqs_rep9_R1, fastqs_rep10_R1]
+        else if length(fastqs_rep9_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
+            fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1, fastqs_rep9_R1]
+        else if length(fastqs_rep8_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
+            fastqs_rep6_R1, fastqs_rep7_R1, fastqs_rep8_R1]
+        else if length(fastqs_rep7_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
+            fastqs_rep6_R1, fastqs_rep7_R1]
+        else if length(fastqs_rep6_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1,
+            fastqs_rep6_R1]
+        else if length(fastqs_rep5_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1, fastqs_rep5_R1]
+        else if length(fastqs_rep4_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1, fastqs_rep4_R1]
+        else if length(fastqs_rep3_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1, fastqs_rep3_R1]
+        else if length(fastqs_rep2_R1)>0 then
+            [fastqs_rep1_R1, fastqs_rep2_R1]
+        else if length(fastqs_rep1_R1)>0 then
+            [fastqs_rep1_R1]
+        else []
+    # no need to do that for R2 (R1 array will be used to determine presense of fastq for each rep)
+    Array[Array[File]] fastqs_R2 = 
+        [fastqs_rep1_R2, fastqs_rep2_R2, fastqs_rep3_R2, fastqs_rep4_R2, fastqs_rep5_R2,
+        fastqs_rep6_R2, fastqs_rep7_R2, fastqs_rep8_R2, fastqs_rep9_R2, fastqs_rep10_R2]
+
+    # temporary 2-dim adapters array [rep_id][merge_id]
+    Array[Array[String]] adapters_R1 = 
+        [adapters_rep1_R1, adapters_rep2_R1, adapters_rep3_R1, adapters_rep4_R1, adapters_rep5_R1,
+        adapters_rep6_R1, adapters_rep7_R1, adapters_rep8_R1, adapters_rep9_R1, adapters_rep10_R1]
+    Array[Array[String]] adapters_R2 = 
+        [adapters_rep1_R2, adapters_rep2_R2, adapters_rep3_R2, adapters_rep4_R2, adapters_rep5_R2,
+        adapters_rep6_R2, adapters_rep7_R2, adapters_rep8_R2, adapters_rep9_R2, adapters_rep10_R2]
+
+    # temporary variables to get number of replicates
+    #       WDLic implementation of max(A,B,C,...)
+    Int num_rep_fastq = length(fastqs_R1)
+    Int num_rep_bam = if length(bams)<num_rep_fastq then num_rep_fastq
+        else length(bams)
+    Int num_rep_nodup_bam = if length(nodup_bams)<num_rep_bam then num_rep_bam
+        else length(nodup_bams)
+    Int num_rep_ta = if length(tas)<num_rep_nodup_bam then num_rep_nodup_bam
+        else length(tas)
+    Int num_rep_peak = if length(peaks)<num_rep_ta then num_rep_ta
+        else length(peaks)
+    Int num_rep = num_rep_peak
+
+    # sanity check for inputs
+    if ( num_rep == 0 ) {
+        call raise_exception as error_input_data  { input:
+            msg = 'No FASTQ/BAM/TAG-ALIGN/PEAK defined in your input JSON. Check if your FASTQs are defined as "atac.fastqs_repX_RY". DO NOT MISS suffix _R1 even for single ended FASTQ.'
+        }
+    }
+
+    # align each replicate
+    scatter(i in range(num_rep)) {
+        # to override endedness definition for individual replicate
+        #     paired_end will override paired_ends[i]
+        Boolean paired_end_ = if !defined(paired_end) && i<length(paired_ends) then paired_ends[i]
+            else select_first([paired_end])
+
+        Boolean has_input_of_align = i<length(fastqs_R1) && length(fastqs_R1[i])>0
+        Boolean has_output_of_align = i<length(bams) && defined(bams[i])
+        if ( has_input_of_align && !has_output_of_align ) {
+            call align { input :
+                fastqs_R1 = fastqs_R1[i],
+                fastqs_R2 = fastqs_R2[i],
+                adapter = adapter,
+                adapters_R1 = adapters_R1[i],
+                adapters_R2 = adapters_R2[i],
+                paired_end = paired_end_,
+                auto_detect_adapter = auto_detect_adapter,
+                cutadapt_param = cutadapt_param,
+
+                aligner = aligner_,
+                mito_chr_name = mito_chr_name_,
+                chrsz = chrsz_,
+                multimapping = multimapping,
+                idx_tar = bowtie2_idx_tar_,
+                # resource
+                cpu = align_cpu,
+                mem_mb = align_mem_mb,
+                time_hr = align_time_hr,
+                disks = align_disks,
+            }
+        }
+        File? bam_ = if has_output_of_align then bams[i] else align.bam
+
+        # mito only mapping to get frac mito qc
+        Boolean has_input_of_align_mito = has_input_of_align &&
+            defined(bowtie2_mito_idx_tar_)
+        if ( has_input_of_align_mito ) {
+            call align as align_mito { input :
+                fastqs_R1 = fastqs_R1[i],
+                fastqs_R2 = fastqs_R2[i],
+                adapter = adapter,
+                adapters_R1 = adapters_R1[i],
+                adapters_R2 = adapters_R2[i],
+                paired_end = paired_end_,
+                auto_detect_adapter = auto_detect_adapter,
+                cutadapt_param = cutadapt_param,
+
+                aligner = aligner_,
+                mito_chr_name = mito_chr_name_,
+                chrsz = chrsz_,
+                multimapping = multimapping,
+                idx_tar = bowtie2_mito_idx_tar_,
+                # resource
+                cpu = align_cpu,
+                mem_mb = align_mem_mb,
+                time_hr = align_time_hr,
+                disks = align_disks,
+            }
+        }
+
+        if ( defined(align.non_mito_samstat_qc) && defined(align_mito.samstat_qc) ) {
+            call frac_mito { input:
+                non_mito_samstat = align.non_mito_samstat_qc,
+                mito_samstat = align_mito.samstat_qc,
+            }
+        }
+
+        Boolean has_input_of_filter = has_output_of_align || defined(align.bam)
+        Boolean has_output_of_filter = i<length(nodup_bams) && defined(nodup_bams[i])
+        # skip if we already have output of this step
+        if ( has_input_of_filter && !has_output_of_filter ) {
+            call filter { input :
+                bam = bam_,
+                paired_end = paired_end_,
+                dup_marker = dup_marker,
+                mapq_thresh = mapq_thresh_,
+                filter_chrs = filter_chrs,
+                chrsz = chrsz_,
+                no_dup_removal = no_dup_removal,
+                multimapping = multimapping,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = filter_cpu,
+                mem_mb = filter_mem_mb,
+                picard_java_heap = filter_picard_java_heap,
+                time_hr = filter_time_hr,
+                disks = filter_disks,
+            }
+        }
+        File? nodup_bam_ = if has_output_of_filter then nodup_bams[i] else filter.nodup_bam
+
+        Boolean has_input_of_bam2ta = has_output_of_filter || defined(filter.nodup_bam)
+        Boolean has_output_of_bam2ta = i<length(tas) && defined(tas[i])
+        if ( has_input_of_bam2ta && !has_output_of_bam2ta ) {
+            call bam2ta { input :
+                bam = nodup_bam_,
+                disable_tn5_shift = if pipeline_type=='atac' then false else true,
+                subsample = subsample_reads,
+                paired_end = paired_end_,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = bam2ta_cpu,
+                mem_mb = bam2ta_mem_mb,
+                time_hr = bam2ta_time_hr,
+                disks = bam2ta_disks,
+            }
+        }
+        File? ta_ = if has_output_of_bam2ta then tas[i] else bam2ta.ta
+
+        Boolean has_input_of_xcor = has_output_of_align || defined(align.bam)
+        if ( has_input_of_xcor && enable_xcor ) {
+            call filter as filter_no_dedup { input :
+                bam = bam_,
+                paired_end = paired_end_,
+                dup_marker = dup_marker,
+                mapq_thresh = mapq_thresh_,
+                filter_chrs = filter_chrs,
+                chrsz = chrsz_,
+                no_dup_removal = true,
+                multimapping = multimapping,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = filter_cpu,
+                mem_mb = filter_mem_mb,
+                picard_java_heap = filter_picard_java_heap,
+                time_hr = filter_time_hr,
+                disks = filter_disks,
+            }
+            call bam2ta as bam2ta_no_dedup { input :
+                bam = filter_no_dedup.nodup_bam,  # output name is nodup but it's not deduped
+                disable_tn5_shift = if pipeline_type=='atac' then false else true,
+                subsample = 0,
+                paired_end = paired_end_,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = bam2ta_cpu,
+                mem_mb = bam2ta_mem_mb,
+                time_hr = bam2ta_time_hr,
+                disks = bam2ta_disks,
+            }
+            # subsample tagalign (non-mito) and cross-correlation analysis
+            call xcor { input :
+                ta = bam2ta_no_dedup.ta,
+                subsample = xcor_subsample_reads,
+                paired_end = paired_end_,
+                mito_chr_name = mito_chr_name_,
+
+                cpu = xcor_cpu,
+                mem_mb = xcor_mem_mb,
+                time_hr = xcor_time_hr,
+                disks = xcor_disks,
+            }
+        }
+
+        Boolean has_input_of_macs2_signal_track = has_output_of_bam2ta || defined(bam2ta.ta)
+        if ( has_input_of_macs2_signal_track ) {
+            # generate count signal track
+            call macs2_signal_track { input :
+                ta = ta_,
+                gensz = gensz_,
+                chrsz = chrsz_,
+                pval_thresh = pval_thresh,
+                smooth_win = smooth_win,
+
+                mem_mb = macs2_signal_track_mem_mb,
+                disks = macs2_signal_track_disks,
+                time_hr = macs2_signal_track_time_hr,
+            }
+        }
+
+        Boolean has_input_of_call_peak = has_output_of_bam2ta || defined(bam2ta.ta)
+        Boolean has_output_of_call_peak = i<length(peaks) && defined(peaks[i])
+        if ( has_input_of_call_peak && !has_output_of_call_peak && !align_only ) {
+            # call peaks on tagalign
+            call call_peak { input :
+                peak_caller = peak_caller_,
+                peak_type = peak_type_,
+                ta = ta_,
+                gensz = gensz_,
+                chrsz = chrsz_,
+                cap_num_peak = cap_num_peak_,
+                pval_thresh = pval_thresh,
+                smooth_win = smooth_win,
+                blacklist = blacklist_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+                cpu = call_peak_cpu,
+                mem_mb = call_peak_mem_mb,
+                disks = call_peak_disks,
+                time_hr = call_peak_time_hr,
+            }
+        }
+        File? peak_ = if has_output_of_call_peak then peaks[i] else call_peak.peak
+
+        Boolean has_input_of_spr = has_output_of_bam2ta || defined(bam2ta.ta)
+        if ( has_input_of_spr && !align_only && !true_rep_only ) {
+            call spr { input :
+                ta = ta_,
+                paired_end = paired_end_,
+                mem_mb = spr_mem_mb,
+            }
+        }
+
+        Boolean has_input_of_call_peak_pr1 = defined(spr.ta_pr1)
+        Boolean has_output_of_call_peak_pr1 = i<length(peaks_pr1) && defined(peaks_pr1[i])
+        if ( has_input_of_call_peak_pr1 && !has_output_of_call_peak_pr1 &&
+            !align_only && !true_rep_only ) {
+            # call peaks on 1st pseudo replicated tagalign 
+            call call_peak as call_peak_pr1 { input :
+                peak_caller = peak_caller_,
+                peak_type = peak_type_,
+                ta = spr.ta_pr1,
+                gensz = gensz_,
+                chrsz = chrsz_,
+                cap_num_peak = cap_num_peak_,
+                pval_thresh = pval_thresh,
+                smooth_win = smooth_win,
+                blacklist = blacklist_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+                cpu = call_peak_cpu,
+                mem_mb = call_peak_mem_mb,
+                disks = call_peak_disks,
+                time_hr = call_peak_time_hr,
+            }
+        }
+        File? peak_pr1_ = if has_output_of_call_peak_pr1 then peaks_pr1[i]
+            else call_peak_pr1.peak
+
+        Boolean has_input_of_call_peak_pr2 = defined(spr.ta_pr2)
+        Boolean has_output_of_call_peak_pr2 = i<length(peaks_pr2) && defined(peaks_pr2[i])
+        if ( has_input_of_call_peak_pr2 && !has_output_of_call_peak_pr2 &&
+            !align_only && !true_rep_only ) {
+            # call peaks on 2nd pseudo replicated tagalign 
+            call call_peak as call_peak_pr2 { input :
+                peak_caller = peak_caller_,
+                peak_type = peak_type_,
+                ta = spr.ta_pr2,
+                gensz = gensz_,
+                chrsz = chrsz_,
+                cap_num_peak = cap_num_peak_,
+                pval_thresh = pval_thresh,
+                smooth_win = smooth_win,
+                blacklist = blacklist_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+                cpu = call_peak_cpu,
+                mem_mb = call_peak_mem_mb,
+                disks = call_peak_disks,
+                time_hr = call_peak_time_hr,
+            }
+        }
+        File? peak_pr2_ = if has_output_of_call_peak_pr2 then peaks_pr2[i]
+            else call_peak_pr2.peak
+
+        Boolean has_input_of_count_signal_track = has_output_of_bam2ta || defined(bam2ta.ta)
+        if ( has_input_of_count_signal_track && enable_count_signal_track ) {
+            # generate count signal track
+            call count_signal_track { input :
+                ta = ta_,
+                chrsz = chrsz_,
+            }
+        }
+        # tasks factored out from ATAqC
+        Boolean has_input_of_tss_enrich = defined(nodup_bam_) && defined(tss_) && (
+            defined(align.read_len) || i<length(read_len) && defined(read_len[i]) )
+        if ( enable_tss_enrich && has_input_of_tss_enrich ) {
+            call tss_enrich { input :
+                read_len = if i<length(read_len) && defined(read_len[i]) then read_len[i]
+                    else align.read_len,
+                nodup_bam = nodup_bam_,
+                tss = tss_,
+                chrsz = chrsz_,
+            }
+        }
+        if ( enable_fraglen_stat && paired_end_ && defined(nodup_bam_) ) {
+            call fraglen_stat_pe { input :
+                nodup_bam = nodup_bam_,
+                picard_java_heap = fraglen_stat_picard_java_heap,
+            }
+        }
+        if ( enable_preseq && defined(bam_) ) {
+            call preseq { input :
+                bam = bam_,
+                paired_end = paired_end_,
+                mem_mb = preseq_mem_mb,
+                picard_java_heap = preseq_picard_java_heap,
+            }
+        }
+        if ( enable_gc_bias && defined(nodup_bam_) && defined(ref_fa_) ) {
+            call gc_bias { input :
+                nodup_bam = nodup_bam_,
+                ref_fa = ref_fa_,
+                picard_java_heap = gc_bias_picard_java_heap,
+            }
+        }
+        if ( enable_annot_enrich && defined(ta_) && defined(blacklist_) && defined(dnase_) && defined(prom_) && defined(enh_) ) {
+            call annot_enrich { input :
+                ta = ta_,
+                blacklist = blacklist_,
+                dnase = dnase_,
+                prom = prom_,
+                enh = enh_,
+            }
+        }
+        if ( enable_compare_to_roadmap && defined(macs2_signal_track.pval_bw) &&
+             defined(reg2map_) && defined(roadmap_meta_) &&
+             ( defined(reg2map_bed_) || defined(dnase_) ) ) {
+            call compare_signal_to_roadmap { input :
+                pval_bw = macs2_signal_track.pval_bw,
+                dnase = dnase_,
+                reg2map_bed = reg2map_bed_,
+                reg2map = reg2map_,
+                roadmap_meta = roadmap_meta_,
+            }
+        }
+    }
+
+    # if there are TAs for ALL replicates then pool them
+    Boolean has_all_inputs_of_pool_ta = length(select_all(ta_))==num_rep
+    if ( has_all_inputs_of_pool_ta && num_rep>1 ) {
+        # pool tagaligns from true replicates
+        call pool_ta { input :
+            tas = ta_,
+            prefix = 'rep',
+        }
+    }
+
+    # if there are pr1 TAs for ALL replicates then pool them
+    Boolean has_all_inputs_of_pool_ta_pr1 = length(select_all(spr.ta_pr1))==num_rep
+    if ( has_all_inputs_of_pool_ta_pr1 && num_rep>1 && !align_only && !true_rep_only ) {
+        # pool tagaligns from pseudo replicate 1
+        call pool_ta as pool_ta_pr1 { input :
+            tas = spr.ta_pr1,
+            prefix = 'rep-pr1',
+        }
+    }
+
+    # if there are pr2 TAs for ALL replicates then pool them
+    Boolean has_all_inputs_of_pool_ta_pr2 = length(select_all(spr.ta_pr2))==num_rep
+    if ( has_all_inputs_of_pool_ta_pr1 && num_rep>1 && !align_only && !true_rep_only ) {
+        # pool tagaligns from pseudo replicate 2
+        call pool_ta as pool_ta_pr2 { input :
+            tas = spr.ta_pr2,
+            prefix = 'rep-pr2',
+        }
+    }
+
+    Boolean has_input_of_call_peak_pooled = defined(pool_ta.ta_pooled)
+    Boolean has_output_of_call_peak_pooled = defined(peak_pooled)
+    if ( has_input_of_call_peak_pooled && !has_output_of_call_peak_pooled &&
+        !align_only && num_rep>1 ) {
+        # call peaks on pooled replicate
+        call call_peak as call_peak_pooled { input :
+            peak_caller = peak_caller_,
+            peak_type = peak_type_,
+            ta = pool_ta.ta_pooled,
+            gensz = gensz_,
+            chrsz = chrsz_,
+            cap_num_peak = cap_num_peak_,
+            pval_thresh = pval_thresh,
+            smooth_win = smooth_win,
+            blacklist = blacklist_,
+            regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+            cpu = call_peak_cpu,
+            mem_mb = call_peak_mem_mb,
+            disks = call_peak_disks,
+            time_hr = call_peak_time_hr,
+        }
+    }
+    File? peak_pooled_ = if has_output_of_call_peak_pooled then peak_pooled
+        else call_peak_pooled.peak
+
+    Boolean has_input_of_count_signal_track_pooled = defined(pool_ta.ta_pooled)
+    if ( has_input_of_count_signal_track_pooled && enable_count_signal_track && num_rep>1 ) {
+        call count_signal_track as count_signal_track_pooled { input :
+            ta = pool_ta.ta_pooled,
+            chrsz = chrsz_,
+        }
+    }
+
+    Boolean has_input_of_macs2_signal_track_pooled = defined(pool_ta.ta_pooled)
+    if ( has_input_of_macs2_signal_track_pooled && num_rep>1 ) {
+        call macs2_signal_track as macs2_signal_track_pooled { input :
+            ta = pool_ta.ta_pooled,
+            gensz = gensz_,
+            chrsz = chrsz_,
+            pval_thresh = pval_thresh,
+            smooth_win = smooth_win,
+
+            mem_mb = macs2_signal_track_mem_mb,
+            disks = macs2_signal_track_disks,
+            time_hr = macs2_signal_track_time_hr,
+        }
+    }
+
+    Boolean has_input_of_jsd = defined(blacklist_) &&
+        length(select_all(nodup_bam_))==num_rep
+    if ( has_input_of_jsd && num_rep > 0 && enable_jsd ) {
+        # fingerprint and JS-distance plot
+        call jsd { input :
+            nodup_bams = nodup_bam_,
+            blacklist = blacklist_,
+            mapq_thresh = mapq_thresh_,
+
+            cpu = jsd_cpu,
+            mem_mb = jsd_mem_mb,
+            time_hr = jsd_time_hr,
+            disks = jsd_disks,
+        }
+    }
+
+    Boolean has_input_of_call_peak_ppr1 = defined(pool_ta_pr1.ta_pooled)
+    Boolean has_output_of_call_peak_ppr1 = defined(peak_ppr1)
+    if ( has_input_of_call_peak_ppr1 && !has_output_of_call_peak_ppr1 &&
+        !align_only && !true_rep_only && num_rep>1 ) {
+        # call peaks on 1st pooled pseudo replicates
+        call call_peak as call_peak_ppr1 { input :
+            peak_caller = peak_caller_,
+            peak_type = peak_type_,
+            ta = pool_ta_pr1.ta_pooled,
+            gensz = gensz_,
+            chrsz = chrsz_,
+            cap_num_peak = cap_num_peak_,
+            pval_thresh = pval_thresh,
+            smooth_win = smooth_win,
+            blacklist = blacklist_,
+            regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+            cpu = call_peak_cpu,
+            mem_mb = call_peak_mem_mb,
+            disks = call_peak_disks,
+            time_hr = call_peak_time_hr,
+        }
+    }
+    File? peak_ppr1_ = if has_output_of_call_peak_ppr1 then peak_ppr1
+        else call_peak_ppr1.peak
+
+    Boolean has_input_of_call_peak_ppr2 = defined(pool_ta_pr2.ta_pooled)
+    Boolean has_output_of_call_peak_ppr2 = defined(peak_ppr2)
+    if ( has_input_of_call_peak_ppr2 && !has_output_of_call_peak_ppr2 &&
+        !align_only && !true_rep_only && num_rep>1 ) {
+        # call peaks on 2nd pooled pseudo replicates
+        call call_peak as call_peak_ppr2 { input :
+            peak_caller = peak_caller_,
+            peak_type = peak_type_,
+            ta = pool_ta_pr2.ta_pooled,
+            gensz = gensz_,
+            chrsz = chrsz_,
+            cap_num_peak = cap_num_peak_,
+            pval_thresh = pval_thresh,
+            smooth_win = smooth_win,
+            blacklist = blacklist_,
+            regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+
+            cpu = call_peak_cpu,
+            mem_mb = call_peak_mem_mb,
+            disks = call_peak_disks,
+            time_hr = call_peak_time_hr,
+        }
+    }
+    File? peak_ppr2_ = if has_output_of_call_peak_ppr2 then peak_ppr2
+        else call_peak_ppr2.peak
+
+    # do IDR/overlap on all pairs of two replicates (i,j)
+    #    where i and j are zero-based indices and 0 <= i < j < num_rep
+    scatter( pair in cross(range(num_rep),range(num_rep)) ) {
+        File? peak1_ = peak_[pair.left]
+        File? peak2_ = peak_[pair.right]
+        if ( !align_only && pair.left<pair.right ) {
+            # pair.left = 0-based index of 1st replicate
+            # pair.right = 0-based index of 2nd replicate
+            # Naive overlap on every pair of true replicates
+            call overlap { input :
+                prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
+                peak1 = peak1_,
+                peak2 = peak2_,
+                peak_pooled = peak_pooled_,
+                peak_type = peak_type_,
+                blacklist = blacklist_,
+                chrsz = chrsz_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+                ta = pool_ta.ta_pooled,
+            }
+        }
+        if ( enable_idr && !align_only && pair.left<pair.right ) {
+            # pair.left = 0-based index of 1st replicate
+            # pair.right = 0-based index of 2nd replicate
+            # IDR on every pair of true replicates
+            call idr { input :
+                prefix = 'rep'+(pair.left+1)+'_vs_rep'+(pair.right+1),
+                peak1 = peak1_,
+                peak2 = peak2_,
+                peak_pooled = peak_pooled_,
+                idr_thresh = idr_thresh,
+                peak_type = peak_type_,
+                rank = idr_rank_,
+                blacklist = blacklist_,
+                chrsz = chrsz_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+                ta = pool_ta.ta_pooled,
+            }
+        }
+    }
+
+    # overlap on pseudo-replicates (pr1, pr2) for each true replicate
+    if ( !align_only && !true_rep_only ) {
+        scatter( i in range(num_rep) ) {
+            call overlap as overlap_pr { input :
+                prefix = 'rep'+(i+1)+'-pr1_vs_rep'+(i+1)+'-pr2',
+                peak1 = peak_pr1_[i],
+                peak2 = peak_pr2_[i],
+                peak_pooled = peak_[i],
+                peak_type = peak_type_,
+                blacklist = blacklist_,
+                chrsz = chrsz_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+                ta = ta_[i],
+            }
+        }
+    }
+
+    if ( !align_only && !true_rep_only && enable_idr ) {
+        scatter( i in range(num_rep) ) {
+            # IDR on pseduo replicates
+            call idr as idr_pr { input :
+                prefix = 'rep'+(i+1)+'-pr1_vs_rep'+(i+1)+'-pr2',
+                peak1 = peak_pr1_[i],
+                peak2 = peak_pr2_[i],
+                peak_pooled = peak_[i],
+                idr_thresh = idr_thresh,
+                peak_type = peak_type_,
+                rank = idr_rank_,
+                blacklist = blacklist_,
+                chrsz = chrsz_,
+                regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+                ta = ta_[i],
+            }
+        }
+    }
+
+    if ( !align_only && !true_rep_only && num_rep>1 ) {
+        # Naive overlap on pooled pseudo replicates
+        call overlap as overlap_ppr { input :
+            prefix = 'pooled-pr1_vs_pooled-pr2',
+            peak1 = peak_ppr1_,
+            peak2 = peak_ppr2_,
+            peak_pooled = peak_pooled_,
+            peak_type = peak_type_,
+            blacklist = blacklist_,
+            chrsz = chrsz_,
+            regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+            ta = pool_ta.ta_pooled,
+        }
+    }
+
+    if ( !align_only && !true_rep_only && num_rep>1 ) {
+        # IDR on pooled pseduo replicates
+        call idr as idr_ppr { input :
+            prefix = 'pooled-pr1_vs_pooled-pr2',
+            peak1 = peak_ppr1_,
+            peak2 = peak_ppr2_,
+            peak_pooled = peak_pooled_,
+            idr_thresh = idr_thresh,
+            peak_type = peak_type_,
+            rank = idr_rank_,
+            blacklist = blacklist_,
+            chrsz = chrsz_,
+            regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name_,
+            ta = pool_ta.ta_pooled,
+        }
+    }
+
+    # reproducibility QC for overlap/IDR peaks
+    if ( !align_only && !true_rep_only && num_rep > 0 ) {
+        # reproducibility QC for overlapping peaks
+        call reproducibility as reproducibility_overlap { input :
+            prefix = 'overlap',
+            peaks = select_all(overlap.bfilt_overlap_peak),
+            peaks_pr = overlap_pr.bfilt_overlap_peak,
+            peak_ppr = overlap_ppr.bfilt_overlap_peak,
+            peak_type = peak_type_,
+            chrsz = chrsz_,
+        }
+    }
+
+    if ( !align_only && !true_rep_only && num_rep > 0 && enable_idr ) {
+        # reproducibility QC for IDR peaks
+        call reproducibility as reproducibility_idr { input :
+            prefix = 'idr',
+            peaks = select_all(idr.bfilt_idr_peak),
+            peaks_pr = idr_pr.bfilt_idr_peak,
+            peak_ppr = idr_ppr.bfilt_idr_peak,
+            peak_type = peak_type_,
+            chrsz = chrsz_,
+        }
+    }
+
+    # Generate final QC report and JSON
+    call qc_report { input :
+        pipeline_ver = pipeline_ver,
+        title = title,
+        description = description,
+        genome = genome_name_,
+        multimapping = multimapping,
+        paired_ends = paired_end_,
+        pipeline_type = pipeline_type,
+        aligner = aligner_,
+        peak_caller = peak_caller_,
+        cap_num_peak = cap_num_peak_,
+        idr_thresh = idr_thresh,
+        pval_thresh = pval_thresh,
+        xcor_subsample_reads = xcor_subsample_reads,
+
+        samstat_qcs = select_all(align.samstat_qc),
+        nodup_samstat_qcs = select_all(filter.samstat_qc),
+
+        frac_mito_qcs = select_all(frac_mito.frac_mito_qc),
+        dup_qcs = select_all(filter.dup_qc),
+        lib_complexity_qcs = select_all(filter.lib_complexity_qc),
+        xcor_plots = select_all(xcor.plot_png),
+        xcor_scores = select_all(xcor.score),
+
+        jsd_plot = jsd.plot,
+        jsd_qcs = jsd.jsd_qcs,
+
+        frip_qcs = select_all(call_peak.frip_qc),
+        frip_qcs_pr1 = select_all(call_peak_pr1.frip_qc),
+        frip_qcs_pr2 = select_all(call_peak_pr2.frip_qc),
+
+        frip_qc_pooled = call_peak_pooled.frip_qc,
+        frip_qc_ppr1 = call_peak_ppr1.frip_qc,
+        frip_qc_ppr2 = call_peak_ppr2.frip_qc,
+
+        idr_plots = select_all(idr.idr_plot),
+        idr_plots_pr = idr_pr.idr_plot,
+        idr_plot_ppr = idr_ppr.idr_plot,
+        frip_idr_qcs = select_all(idr.frip_qc),
+        frip_idr_qcs_pr = idr_pr.frip_qc,
+        frip_idr_qc_ppr = idr_ppr.frip_qc,
+        frip_overlap_qcs = select_all(overlap.frip_qc),
+        frip_overlap_qcs_pr = overlap_pr.frip_qc,
+        frip_overlap_qc_ppr = overlap_ppr.frip_qc,
+        idr_reproducibility_qc = reproducibility_idr.reproducibility_qc,
+        overlap_reproducibility_qc = reproducibility_overlap.reproducibility_qc,
+
+        annot_enrich_qcs = select_all(annot_enrich.annot_enrich_qc),
+        tss_enrich_qcs = select_all(tss_enrich.tss_enrich_qc),
+        tss_large_plots = select_all(tss_enrich.tss_large_plot),
+        roadmap_compare_plots = select_all(compare_signal_to_roadmap.roadmap_compare_plot),
+        fraglen_dist_plots = select_all(fraglen_stat_pe.fraglen_dist_plot),
+        fraglen_nucleosomal_qcs = select_all(fraglen_stat_pe.nucleosomal_qc),
+        gc_plots = select_all(gc_bias.gc_plot),
+        preseq_plots = select_all(preseq.preseq_plot),
+        picard_est_lib_size_qcs = select_all(preseq.picard_est_lib_size_qc),
+
+        peak_region_size_qcs = select_all(call_peak.peak_region_size_qc),
+        peak_region_size_plots = select_all(call_peak.peak_region_size_plot),
+        num_peak_qcs = select_all(call_peak.num_peak_qc),
+
+        idr_opt_peak_region_size_qc = reproducibility_idr.peak_region_size_qc,
+        idr_opt_peak_region_size_plot = reproducibility_overlap.peak_region_size_plot,
+        idr_opt_num_peak_qc = reproducibility_idr.num_peak_qc,
+
+        overlap_opt_peak_region_size_qc = reproducibility_overlap.peak_region_size_qc,
+        overlap_opt_peak_region_size_plot = reproducibility_overlap.peak_region_size_plot,
+        overlap_opt_num_peak_qc = reproducibility_overlap.num_peak_qc,
+    }
+
+    output {
+        File report = qc_report.report
+        File qc_json = qc_report.qc_json
+        Boolean qc_json_ref_match = qc_report.qc_json_ref_match
+    }
 }
 
 task align {
-	input {
-		# for task trim_adapter
-		Array[File] fastqs_R1		 # [merge_id]
-		Array[File] fastqs_R2
+    input {
+        # for task trim_adapter
+        Array[File] fastqs_R1         # [merge_id]
+        Array[File] fastqs_R2
 
-		String? adapter	 # adapter for all fastqs,
-							#	this will override individual adapters in adapters_R1/R2
-		Array[String] adapters_R1
-		Array[String] adapters_R2
-		Boolean paired_end
-		Boolean auto_detect_adapter
-		String cutadapt_param
+        String? adapter     # adapter for all fastqs,
+                            #    this will override individual adapters in adapters_R1/R2
+        Array[String] adapters_R1
+        Array[String] adapters_R2
+        Boolean paired_end
+        Boolean auto_detect_adapter
+        String cutadapt_param
 
-		# for task align
-		String aligner
-		String mito_chr_name
-		File chrsz			# 2-col chromosome sizes file
-		File idx_tar		# reference index tar or tar.gz
-		Int multimapping
+        # for task align
+        String aligner
+        String mito_chr_name
+        File chrsz            # 2-col chromosome sizes file
+        File idx_tar        # reference index tar or tar.gz
+        Int multimapping
 
-		# resource
-		Int cpu
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
+        # resource
+        Int cpu
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
 
-	# tmp vars for task trim_adapter
-	Array[Array[File]] tmp_fastqs = if paired_end then transpose([fastqs_R1, fastqs_R2])
-				else transpose([fastqs_R1])
-	Array[Array[String]] tmp_adapters = if paired_end then transpose([adapters_R1, adapters_R2])
-				else transpose([adapters_R1])
-	command {
-		set -e
+    # tmp vars for task trim_adapter
+    Array[Array[File]] tmp_fastqs = if paired_end then transpose([fastqs_R1, fastqs_R2])
+                else transpose([fastqs_R1])
+    Array[Array[String]] tmp_adapters = if paired_end then transpose([adapters_R1, adapters_R2])
+                else transpose([adapters_R1])
+    command {
+        set -e
 
-		# check if pipeline dependencies can be found
-		if [[ -z "$(which encode_task_trim_adapter.py 2> /dev/null || true)" ]]
-		then
-		  echo -e "\n* Error: pipeline dependencies not found." 1>&2
-		  echo 'Conda users: Did you activate Conda environment (conda activate encode-atac-seq-pipeline)?' 1>&2
-		  echo '	Or did you install Conda and environment correctly (bash scripts/install_conda_env.sh)?' 1>&2
-		  echo 'GCP/AWS/Docker users: Did you add --docker flag to Caper command line arg?' 1>&2
-		  echo 'Singularity users: Did you add --singularity flag to Caper command line arg?' 1>&2
-		  echo -e "\n" 1>&2
-		  exit 3
-		fi
+        # check if pipeline dependencies can be found
+        if [[ -z "$(which encode_task_trim_adapter.py 2> /dev/null || true)" ]]
+        then
+          echo -e "\n* Error: pipeline dependencies not found." 1>&2
+          echo 'Conda users: Did you activate Conda environment (conda activate encode-atac-seq-pipeline)?' 1>&2
+          echo '    Or did you install Conda and environment correctly (bash scripts/install_conda_env.sh)?' 1>&2
+          echo 'GCP/AWS/Docker users: Did you add --docker flag to Caper command line arg?' 1>&2
+          echo 'Singularity users: Did you add --singularity flag to Caper command line arg?' 1>&2
+          echo -e "\n" 1>&2
+          exit 3
+        fi
 
-		# trim adapter
-		python3 $(which encode_task_trim_adapter.py) \
-			${write_tsv(tmp_fastqs)} \
-			${'--adapter ' + adapter} \
-			--adapters ${write_tsv(tmp_adapters)} \
-			${if paired_end then '--paired-end' else ''} \
-			${if auto_detect_adapter then '--auto-detect-adapter' else ''} \
-			--cutadapt-param ' ${cutadapt_param}' \
-			${'--nth ' + cpu}
+        # trim adapter
+        python3 $(which encode_task_trim_adapter.py) \
+            ${write_tsv(tmp_fastqs)} \
+            ${'--adapter ' + adapter} \
+            --adapters ${write_tsv(tmp_adapters)} \
+            ${if paired_end then '--paired-end' else ''} \
+            ${if auto_detect_adapter then '--auto-detect-adapter' else ''} \
+            --cutadapt-param ' ${cutadapt_param}' \
+            ${'--nth ' + cpu}
 
-		# align on trimmed/merged fastqs
-		if [ '${aligner}' == 'bowtie2' ]; then
-			python3 $(which encode_task_bowtie2.py) \
-				${idx_tar} \
-				R1/*.fastq.gz \
-				${if paired_end then 'R2/*.fastq.gz' else ''} \
-				${if paired_end then '--paired-end' else ''} \
-				${'--multimapping ' + multimapping} \
-				${'--nth ' + cpu}
-		fi
+        # align on trimmed/merged fastqs
+        if [ '${aligner}' == 'bowtie2' ]; then
+            python3 $(which encode_task_bowtie2.py) \
+                ${idx_tar} \
+                R1/*.fastq.gz \
+                ${if paired_end then 'R2/*.fastq.gz' else ''} \
+                ${if paired_end then '--paired-end' else ''} \
+                ${'--multimapping ' + multimapping} \
+                ${'--nth ' + cpu}
+        fi
 
-		python3 $(which encode_task_post_align.py) \
-			R1/*.fastq.gz $(ls *.bam) \
-			${'--mito-chr-name ' + mito_chr_name} \
-			${'--chrsz ' + chrsz} \
-			${'--nth ' + cpu}
-		rm -rf R1 R2
-	}
-	output {
-		File bam = glob('*.bam')[0]
-		File bai = glob('*.bai')[0]
-		File samstat_qc = glob('*.samstats.qc')[0]
-		File non_mito_samstat_qc = glob('non_mito/*.samstats.qc')[0]
-		File read_len_log = glob('*.read_length.txt')[0]
-		Int read_len = read_int(read_len_log)
-	}
-	runtime {
-		cpu : cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-		preemptible: 0
-	}
+        python3 $(which encode_task_post_align.py) \
+            R1/*.fastq.gz $(ls *.bam) \
+            ${'--mito-chr-name ' + mito_chr_name} \
+            ${'--chrsz ' + chrsz} \
+            ${'--nth ' + cpu}
+        rm -rf R1 R2
+    }
+    output {
+        File bam = glob('*.bam')[0]
+        File bai = glob('*.bai')[0]
+        File samstat_qc = glob('*.samstats.qc')[0]
+        File non_mito_samstat_qc = glob('non_mito/*.samstats.qc')[0]
+        File read_len_log = glob('*.read_length.txt')[0]
+        Int read_len = read_int(read_len_log)
+    }
+    runtime {
+        cpu : cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+        preemptible: 0
+    }
 }
 
 task frac_mito {
-	input {
-		File? non_mito_samstat
-		File? mito_samstat
-	}
+    input {
+        File? non_mito_samstat
+        File? mito_samstat
+    }
 
-	command {
-		python3 $(which encode_task_frac_mito.py) \
-			${non_mito_samstat} ${mito_samstat}
-	}
-	output {
-		File frac_mito_qc = glob('*.frac_mito.qc')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '8000 MB'
-		time : 1
-		disks : 'local-disk 100 HDD'
-	}
+    command {
+        python3 $(which encode_task_frac_mito.py) \
+            ${non_mito_samstat} ${mito_samstat}
+    }
+    output {
+        File frac_mito_qc = glob('*.frac_mito.qc')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '8000 MB'
+        time : 1
+        disks : 'local-disk 100 HDD'
+    }
 }
 
 task filter {
-	input {
-		File? bam
-		Boolean paired_end
-		Int multimapping
-		String dup_marker			 # picard.jar MarkDuplicates (picard) or 
-									# sambamba markdup (sambamba)
-		Int mapq_thresh				# threshold for low MAPQ reads removal
-		Array[String] filter_chrs	 # chrs to be removed from final (nodup/filt) BAM
-		File chrsz					# 2-col chromosome sizes file
-		Boolean no_dup_removal		 # no dupe reads removal when filtering BAM
-		String mito_chr_name
+    input {
+        File? bam
+        Boolean paired_end
+        Int multimapping
+        String dup_marker             # picard.jar MarkDuplicates (picard) or 
+                                    # sambamba markdup (sambamba)
+        Int mapq_thresh                # threshold for low MAPQ reads removal
+        Array[String] filter_chrs     # chrs to be removed from final (nodup/filt) BAM
+        File chrsz                    # 2-col chromosome sizes file
+        Boolean no_dup_removal         # no dupe reads removal when filtering BAM
+        String mito_chr_name
 
-		Int cpu
-		Int mem_mb
-		String? picard_java_heap
-		Int time_hr
-		String disks
-	}
-	Float picard_java_heap_factor = 0.9
+        Int cpu
+        Int mem_mb
+        String? picard_java_heap
+        Int time_hr
+        String disks
+    }
+    Float picard_java_heap_factor = 0.9
 
-	command {
-		python3 $(which encode_task_filter.py) \
-			${bam} \
-			${if paired_end then '--paired-end' else ''} \
-			${'--multimapping ' + multimapping} \
-			${'--dup-marker ' + dup_marker} \
-			${'--mapq-thresh ' + mapq_thresh} \
-			--filter-chrs ${sep=' ' filter_chrs} \
-			${'--chrsz ' + chrsz} \
-			${if no_dup_removal then '--no-dup-removal' else ''} \
-			${'--mito-chr-name ' + mito_chr_name} \
-			${'--nth ' + cpu} \
-			${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
-	}
-	output {
-		File nodup_bam = glob('*.bam')[0]
-		File nodup_bai = glob('*.bai')[0]
-		File samstat_qc = glob('*.samstats.qc')[0]
-		File dup_qc = glob('*.dup.qc')[0]
-		File lib_complexity_qc = glob('*.lib_complexity.qc')[0]
-	}
-	runtime {
-		cpu : cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-	}
+    command {
+        python3 $(which encode_task_filter.py) \
+            ${bam} \
+            ${if paired_end then '--paired-end' else ''} \
+            ${'--multimapping ' + multimapping} \
+            ${'--dup-marker ' + dup_marker} \
+            ${'--mapq-thresh ' + mapq_thresh} \
+            --filter-chrs ${sep=' ' filter_chrs} \
+            ${'--chrsz ' + chrsz} \
+            ${if no_dup_removal then '--no-dup-removal' else ''} \
+            ${'--mito-chr-name ' + mito_chr_name} \
+            ${'--nth ' + cpu} \
+            ${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
+    }
+    output {
+        File nodup_bam = glob('*.bam')[0]
+        File nodup_bai = glob('*.bai')[0]
+        File samstat_qc = glob('*.samstats.qc')[0]
+        File dup_qc = glob('*.dup.qc')[0]
+        File lib_complexity_qc = glob('*.lib_complexity.qc')[0]
+    }
+    runtime {
+        cpu : cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+    }
 }
 
 task bam2ta {
-	input {
-		File? bam
-		Boolean paired_end
-		Boolean disable_tn5_shift	 # no tn5 shifting (it's for dnase-seq)
-		String mito_chr_name		 # mito chromosome name
-		Int subsample				 # number of reads to subsample TAGALIGN
-									# this affects all downstream analysis
-		Int cpu
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
+    input {
+        File? bam
+        Boolean paired_end
+        Boolean disable_tn5_shift     # no tn5 shifting (it's for dnase-seq)
+        String mito_chr_name         # mito chromosome name
+        Int subsample                 # number of reads to subsample TAGALIGN
+                                    # this affects all downstream analysis
+        Int cpu
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
 
-	command {
-		python3 $(which encode_task_bam2ta.py) \
-			${bam} \
-			${if paired_end then '--paired-end' else ''} \
-			${if disable_tn5_shift then '--disable-tn5-shift' else ''} \
-			${'--mito-chr-name ' + mito_chr_name} \
-			${'--subsample ' + subsample} \
-			${'--nth ' + cpu}
-	}
-	output {
-		File ta = glob('*.tagAlign.gz')[0]
-	}
-	runtime {
-		cpu : cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-	}
+    command {
+        python3 $(which encode_task_bam2ta.py) \
+            ${bam} \
+            ${if paired_end then '--paired-end' else ''} \
+            ${if disable_tn5_shift then '--disable-tn5-shift' else ''} \
+            ${'--mito-chr-name ' + mito_chr_name} \
+            ${'--subsample ' + subsample} \
+            ${'--nth ' + cpu}
+    }
+    output {
+        File ta = glob('*.tagAlign.gz')[0]
+    }
+    runtime {
+        cpu : cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+    }
 }
 
 task spr {
-	# make two self pseudo replicates
-	input {
-		File? ta
-		Boolean paired_end
+    # make two self pseudo replicates
+    input {
+        File? ta
+        Boolean paired_end
 
-		Int mem_mb
-	}
+        Int mem_mb
+    }
 
-	command {
-		python3 $(which encode_task_spr.py) \
-			${ta} \
-			${if paired_end then '--paired-end' else ''}
-	}
-	output {
-		File ta_pr1 = glob('*.pr1.tagAlign.gz')[0]
-		File ta_pr2 = glob('*.pr2.tagAlign.gz')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '${mem_mb} MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}
+    command {
+        python3 $(which encode_task_spr.py) \
+            ${ta} \
+            ${if paired_end then '--paired-end' else ''}
+    }
+    output {
+        File ta_pr1 = glob('*.pr1.tagAlign.gz')[0]
+        File ta_pr2 = glob('*.pr2.tagAlign.gz')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '${mem_mb} MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task pool_ta {
-	input {
-		Array[File?] tas	 # TAG-ALIGNs to be merged
-		Int? col			 # number of columns in pooled TA
-		String? prefix		 # basename prefix
-	}
-	command {
-		python3 $(which encode_task_pool_ta.py) \
-			${sep=' ' select_all(tas)} \
-			${'--prefix ' + prefix} \
-			${'--col ' + col}
-	}
-	output {
-		File ta_pooled = glob('*.tagAlign.gz')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}
+    input {
+        Array[File?] tas     # TAG-ALIGNs to be merged
+        Int? col             # number of columns in pooled TA
+        String? prefix         # basename prefix
+    }
+    command {
+        python3 $(which encode_task_pool_ta.py) \
+            ${sep=' ' select_all(tas)} \
+            ${'--prefix ' + prefix} \
+            ${'--col ' + col}
+    }
+    output {
+        File ta_pooled = glob('*.tagAlign.gz')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task xcor {
-	input {
-		File? ta
-		Boolean paired_end
-		String mito_chr_name
-		Int subsample  # number of reads to subsample TAGALIGN
-					# this will be used for xcor only
-					# will not affect any downstream analysis
-		Int cpu
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
+    input {
+        File? ta
+        Boolean paired_end
+        String mito_chr_name
+        Int subsample  # number of reads to subsample TAGALIGN
+                    # this will be used for xcor only
+                    # will not affect any downstream analysis
+        Int cpu
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
 
-	command {
-		python3 $(which encode_task_xcor.py) \
-			${ta} \
-			${if paired_end then '--paired-end' else ''} \
-			${'--mito-chr-name ' + mito_chr_name} \
-			${'--subsample ' + subsample} \
-			--speak=0 \
-			${'--nth ' + cpu}
-	}
-	output {
-		File plot_pdf = glob('*.cc.plot.pdf')[0]
-		File plot_png = glob('*.cc.plot.png')[0]
-		File score = glob('*.cc.qc')[0]
-	}
-	runtime {
-		cpu : cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-	}
+    command {
+        python3 $(which encode_task_xcor.py) \
+            ${ta} \
+            ${if paired_end then '--paired-end' else ''} \
+            ${'--mito-chr-name ' + mito_chr_name} \
+            ${'--subsample ' + subsample} \
+            --speak=0 \
+            ${'--nth ' + cpu}
+    }
+    output {
+        File plot_pdf = glob('*.cc.plot.pdf')[0]
+        File plot_png = glob('*.cc.plot.png')[0]
+        File score = glob('*.cc.qc')[0]
+    }
+    runtime {
+        cpu : cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+    }
 }
 
 task jsd {
-	input {
-		Array[File?] nodup_bams
-		File? blacklist
-		Int mapq_thresh
+    input {
+        Array[File?] nodup_bams
+        File? blacklist
+        Int mapq_thresh
 
-		Int cpu
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
+        Int cpu
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
 
-	command {
-		python3 $(which encode_task_jsd.py) \
-			${sep=' ' select_all(nodup_bams)} \
-			${'--mapq-thresh '+ mapq_thresh} \
-			${'--blacklist '+ blacklist} \
-			${'--nth ' + cpu}
-	}
-	output {
-		File plot = glob('*.png')[0]
-		Array[File] jsd_qcs = glob('*.jsd.qc')
-	}
-	runtime {
-		cpu : cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-	}
+    command {
+        python3 $(which encode_task_jsd.py) \
+            ${sep=' ' select_all(nodup_bams)} \
+            ${'--mapq-thresh '+ mapq_thresh} \
+            ${'--blacklist '+ blacklist} \
+            ${'--nth ' + cpu}
+    }
+    output {
+        File plot = glob('*.png')[0]
+        Array[File] jsd_qcs = glob('*.jsd.qc')
+    }
+    runtime {
+        cpu : cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+    }
 }
 
 task count_signal_track {
-	input {
-		File? ta			 # tag-align
-		File chrsz			# 2-col chromosome sizes file
-	}
-	command {
-		python3 $(which encode_task_count_signal_track.py) \
-			${ta} \
-			${'--chrsz ' + chrsz}
-	}
-	output {
-		File pos_bw = glob('*.positive.bigwig')[0]
-		File neg_bw = glob('*.negative.bigwig')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '8000 MB'
-		time : 4
-		disks : 'local-disk 50 HDD'
-	}
+    input {
+        File? ta             # tag-align
+        File chrsz            # 2-col chromosome sizes file
+    }
+    command {
+        python3 $(which encode_task_count_signal_track.py) \
+            ${ta} \
+            ${'--chrsz ' + chrsz}
+    }
+    output {
+        File pos_bw = glob('*.positive.bigwig')[0]
+        File neg_bw = glob('*.negative.bigwig')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '8000 MB'
+        time : 4
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task call_peak {
-	input {
-		String peak_caller
-		String peak_type
+    input {
+        String peak_caller
+        String peak_type
 
-		File? ta
-		String gensz		# Genome size (sum of entries in 2nd column of 
-							# chr. sizes file, or hs for human, ms for mouse)
-		File chrsz			# 2-col chromosome sizes file
-		Int cap_num_peak	# cap number of raw peaks called from MACS2
-		Float pval_thresh	  # p.value threshold
-		Int smooth_win		 # size of smoothing window
-		File? blacklist	 # blacklist BED to filter raw peaks
-		String? regex_bfilt_peak_chr_name
+        File? ta
+        String gensz        # Genome size (sum of entries in 2nd column of 
+                            # chr. sizes file, or hs for human, ms for mouse)
+        File chrsz            # 2-col chromosome sizes file
+        Int cap_num_peak    # cap number of raw peaks called from MACS2
+        Float pval_thresh      # p.value threshold
+        Int smooth_win         # size of smoothing window
+        File? blacklist     # blacklist BED to filter raw peaks
+        String? regex_bfilt_peak_chr_name
 
-		Int cpu
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
-	command {
-		set -e
+        Int cpu
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
+    command {
+        set -e
 
-		if [ '${peak_caller}' == 'macs2' ]; then
-			python3 $(which encode_task_macs2_atac.py) \
-				${ta} \
-				${'--gensz ' + gensz} \
-				${'--chrsz ' + chrsz} \
-				${'--cap-num-peak ' + cap_num_peak} \
-				${'--pval-thresh '+ pval_thresh} \
-				${'--smooth-win '+ smooth_win}
-		fi
+        if [ '${peak_caller}' == 'macs2' ]; then
+            python3 $(which encode_task_macs2_atac.py) \
+                ${ta} \
+                ${'--gensz ' + gensz} \
+                ${'--chrsz ' + chrsz} \
+                ${'--cap-num-peak ' + cap_num_peak} \
+                ${'--pval-thresh '+ pval_thresh} \
+                ${'--smooth-win '+ smooth_win}
+        fi
 
-		python3 $(which encode_task_post_call_peak_atac.py) \
-			$(ls *Peak.gz) \
-			${'--ta ' + ta} \
-			${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
-			${'--chrsz ' + chrsz} \
-			${'--peak-type ' + peak_type} \
-			${'--blacklist ' + blacklist}
-	}
-	output {
-		File peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
-		# generated by post_call_peak py
-		File bfilt_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
-		File bfilt_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
-		File bfilt_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
-		File bfilt_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
-		File frip_qc = glob('*.frip.qc')[0]
-		File peak_region_size_qc = glob('*.peak_region_size.qc')[0]
-		File peak_region_size_plot = glob('*.peak_region_size.png')[0]
-		File num_peak_qc = glob('*.num_peak.qc')[0]
-	}
-	runtime {
-		cpu : if peak_caller == 'macs2' then 1 else cpu
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-		preemptible: 0
-	}
+        python3 $(which encode_task_post_call_peak_atac.py) \
+            $(ls *Peak.gz) \
+            ${'--ta ' + ta} \
+            ${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
+            ${'--chrsz ' + chrsz} \
+            ${'--peak-type ' + peak_type} \
+            ${'--blacklist ' + blacklist}
+    }
+    output {
+        File peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
+        # generated by post_call_peak py
+        File bfilt_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
+        File bfilt_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
+        File bfilt_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
+        File bfilt_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
+        File frip_qc = glob('*.frip.qc')[0]
+        File peak_region_size_qc = glob('*.peak_region_size.qc')[0]
+        File peak_region_size_plot = glob('*.peak_region_size.png')[0]
+        File num_peak_qc = glob('*.num_peak.qc')[0]
+    }
+    runtime {
+        cpu : if peak_caller == 'macs2' then 1 else cpu
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+        preemptible: 0
+    }
 }
 
 task macs2_signal_track {
-	input {
-		File? ta
-		String gensz		# Genome size (sum of entries in 2nd column of 
-							# chr. sizes file, or hs for human, ms for mouse)
-		File chrsz			# 2-col chromosome sizes file
-		Float pval_thresh	  # p.value threshold
-		Int smooth_win		 # size of smoothing window
+    input {
+        File? ta
+        String gensz        # Genome size (sum of entries in 2nd column of 
+                            # chr. sizes file, or hs for human, ms for mouse)
+        File chrsz            # 2-col chromosome sizes file
+        Float pval_thresh      # p.value threshold
+        Int smooth_win         # size of smoothing window
 
-		Int mem_mb
-		Int time_hr
-		String disks
-	}
-	command {
-		python3 $(which encode_task_macs2_signal_track_atac.py) \
-			${ta} \
-			${'--gensz '+ gensz} \
-			${'--chrsz ' + chrsz} \
-			${'--pval-thresh '+ pval_thresh} \
-			${'--smooth-win '+ smooth_win}
-	}
-	output {
-		File pval_bw = glob('*.pval.signal.bigwig')[0]
-		File fc_bw = glob('*.fc.signal.bigwig')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '${mem_mb} MB'
-		time : time_hr
-		disks : disks
-		preemptible: 0
-	}
+        Int mem_mb
+        Int time_hr
+        String disks
+    }
+    command {
+        python3 $(which encode_task_macs2_signal_track_atac.py) \
+            ${ta} \
+            ${'--gensz '+ gensz} \
+            ${'--chrsz ' + chrsz} \
+            ${'--pval-thresh '+ pval_thresh} \
+            ${'--smooth-win '+ smooth_win}
+    }
+    output {
+        File pval_bw = glob('*.pval.signal.bigwig')[0]
+        File fc_bw = glob('*.fc.signal.bigwig')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '${mem_mb} MB'
+        time : time_hr
+        disks : disks
+        preemptible: 0
+    }
 }
 
 task idr {
-	input {
-		String prefix		 # prefix for IDR output file
-		File? peak1
-		File? peak2
-		File? peak_pooled
-		Float idr_thresh
-		File? blacklist	 # blacklist BED to filter raw peaks
-		String regex_bfilt_peak_chr_name
-		# parameters to compute FRiP
-		File? ta			# to calculate FRiP
-		File chrsz			# 2-col chromosome sizes file
-		String peak_type
-		String rank
-	}
-	command {
-		${if defined(ta) then '' else 'touch null.frip.qc'}
-		touch null
-		python3 $(which encode_task_idr.py) \
-			${peak1} ${peak2} ${peak_pooled} \
-			${'--prefix ' + prefix} \
-			${'--idr-thresh ' + idr_thresh} \
-			${'--peak-type ' + peak_type} \
-			--idr-rank ${rank} \
-			${'--chrsz ' + chrsz} \
-			${'--blacklist '+ blacklist} \
-			${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
-			${'--ta ' + ta}
-	}
-	output {
-		File idr_peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
-		File bfilt_idr_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
-		File bfilt_idr_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
-		File bfilt_idr_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
-		File bfilt_idr_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
-		File idr_plot = glob('*.txt.png')[0]
-		File idr_unthresholded_peak = glob('*.txt.gz')[0]
-		File idr_log = glob('*.idr*.log')[0]
-		File frip_qc = if defined(ta) then glob('*.frip.qc')[0] else glob('null')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '8000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}
+    input {
+        String prefix         # prefix for IDR output file
+        File? peak1
+        File? peak2
+        File? peak_pooled
+        Float idr_thresh
+        File? blacklist     # blacklist BED to filter raw peaks
+        String regex_bfilt_peak_chr_name
+        # parameters to compute FRiP
+        File? ta            # to calculate FRiP
+        File chrsz            # 2-col chromosome sizes file
+        String peak_type
+        String rank
+    }
+    command {
+        ${if defined(ta) then '' else 'touch null.frip.qc'}
+        touch null
+        python3 $(which encode_task_idr.py) \
+            ${peak1} ${peak2} ${peak_pooled} \
+            ${'--prefix ' + prefix} \
+            ${'--idr-thresh ' + idr_thresh} \
+            ${'--peak-type ' + peak_type} \
+            --idr-rank ${rank} \
+            ${'--chrsz ' + chrsz} \
+            ${'--blacklist '+ blacklist} \
+            ${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
+            ${'--ta ' + ta}
+    }
+    output {
+        File idr_peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
+        File bfilt_idr_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
+        File bfilt_idr_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
+        File bfilt_idr_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
+        File bfilt_idr_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
+        File idr_plot = glob('*.txt.png')[0]
+        File idr_unthresholded_peak = glob('*.txt.gz')[0]
+        File idr_log = glob('*.idr*.log')[0]
+        File frip_qc = if defined(ta) then glob('*.frip.qc')[0] else glob('null')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '8000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task overlap {
-	input {
-		String prefix		 # prefix for IDR output file
-		File? peak1
-		File? peak2
-		File? peak_pooled
-		File? blacklist	 # blacklist BED to filter raw peaks
-		String regex_bfilt_peak_chr_name
-		File? ta		# to calculate FRiP
-		File chrsz			# 2-col chromosome sizes file
-		String peak_type
-	}
-	command {
-		${if defined(ta) then '' else 'touch null.frip.qc'}
-		touch null 
-		python3 $(which encode_task_overlap.py) \
-			${peak1} ${peak2} ${peak_pooled} \
-			${'--prefix ' + prefix} \
-			${'--peak-type ' + peak_type} \
-			${'--chrsz ' + chrsz} \
-			${'--blacklist '+ blacklist} \
-			--nonamecheck \
-			${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
-			${'--ta ' + ta}
-	}
-	output {
-		File overlap_peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
-		File bfilt_overlap_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
-		File bfilt_overlap_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
-		File bfilt_overlap_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
-		File bfilt_overlap_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
-		File frip_qc = if defined(ta) then glob('*.frip.qc')[0] else glob('null')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}
+    input {
+        String prefix         # prefix for IDR output file
+        File? peak1
+        File? peak2
+        File? peak_pooled
+        File? blacklist     # blacklist BED to filter raw peaks
+        String regex_bfilt_peak_chr_name
+        File? ta        # to calculate FRiP
+        File chrsz            # 2-col chromosome sizes file
+        String peak_type
+    }
+    command {
+        ${if defined(ta) then '' else 'touch null.frip.qc'}
+        touch null 
+        python3 $(which encode_task_overlap.py) \
+            ${peak1} ${peak2} ${peak_pooled} \
+            ${'--prefix ' + prefix} \
+            ${'--peak-type ' + peak_type} \
+            ${'--chrsz ' + chrsz} \
+            ${'--blacklist '+ blacklist} \
+            --nonamecheck \
+            ${'--regex-bfilt-peak-chr-name \'' + regex_bfilt_peak_chr_name + '\''} \
+            ${'--ta ' + ta}
+    }
+    output {
+        File overlap_peak = glob('*[!.][!b][!f][!i][!l][!t].'+peak_type+'.gz')[0]
+        File bfilt_overlap_peak = glob('*.bfilt.'+peak_type+'.gz')[0]
+        File bfilt_overlap_peak_bb = glob('*.bfilt.'+peak_type+'.bb')[0]
+        File bfilt_overlap_peak_hammock = glob('*.bfilt.'+peak_type+'.hammock.gz*')[0]
+        File bfilt_overlap_peak_hammock_tbi = glob('*.bfilt.'+peak_type+'.hammock.gz*')[1]
+        File frip_qc = if defined(ta) then glob('*.frip.qc')[0] else glob('null')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task reproducibility {
-	input {
-		String prefix
-		Array[File] peaks # peak files from pair of true replicates
-							# in a sorted order. for example of 4 replicates,
-							# 1,2 1,3 1,4 2,3 2,4 3,4.
-							# x,y means peak file from rep-x vs rep-y
-		Array[File]? peaks_pr	# peak files from pseudo replicates
-		File? peak_ppr			# Peak file from pooled pseudo replicate.
-		String peak_type
-		File chrsz			# 2-col chromosome sizes file
-	}
-	command {
-		python3 $(which encode_task_reproducibility.py) \
-			${sep=' ' peaks} \
-			--peaks-pr ${sep=' ' peaks_pr} \
-			${'--peak-ppr '+ peak_ppr} \
-			--prefix ${prefix} \
-			${'--peak-type ' + peak_type} \
-			${'--chrsz ' + chrsz}
-	}
-	output {
-		File optimal_peak = glob('*optimal_peak.*.gz')[0]
-		File optimal_peak_bb = glob('*optimal_peak.*.bb')[0]
-		File optimal_peak_hammock = glob('*optimal_peak.*.hammock.gz*')[0]
-		File optimal_peak_hammock_tbi = glob('*optimal_peak.*.hammock.gz*')[1]
-		File conservative_peak = glob('*conservative_peak.*.gz')[0]
-		File conservative_peak_bb = glob('*conservative_peak.*.bb')[0]
-		File conservative_peak_hammock = glob('*conservative_peak.*.hammock.gz*')[0]
-		File conservative_peak_hammock_tbi = glob('*conservative_peak.*.hammock.gz*')[1]
-		File reproducibility_qc = glob('*reproducibility.qc')[0]
-		# QC metrics for optimal peak
-		File peak_region_size_qc = glob('*.peak_region_size.qc')[0]
-		File peak_region_size_plot = glob('*.peak_region_size.png')[0]
-		File num_peak_qc = glob('*.num_peak.qc')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}
+    input {
+        String prefix
+        Array[File] peaks # peak files from pair of true replicates
+                            # in a sorted order. for example of 4 replicates,
+                            # 1,2 1,3 1,4 2,3 2,4 3,4.
+                            # x,y means peak file from rep-x vs rep-y
+        Array[File]? peaks_pr    # peak files from pseudo replicates
+        File? peak_ppr            # Peak file from pooled pseudo replicate.
+        String peak_type
+        File chrsz            # 2-col chromosome sizes file
+    }
+    command {
+        python3 $(which encode_task_reproducibility.py) \
+            ${sep=' ' peaks} \
+            --peaks-pr ${sep=' ' peaks_pr} \
+            ${'--peak-ppr '+ peak_ppr} \
+            --prefix ${prefix} \
+            ${'--peak-type ' + peak_type} \
+            ${'--chrsz ' + chrsz}
+    }
+    output {
+        File optimal_peak = glob('*optimal_peak.*.gz')[0]
+        File optimal_peak_bb = glob('*optimal_peak.*.bb')[0]
+        File optimal_peak_hammock = glob('*optimal_peak.*.hammock.gz*')[0]
+        File optimal_peak_hammock_tbi = glob('*optimal_peak.*.hammock.gz*')[1]
+        File conservative_peak = glob('*conservative_peak.*.gz')[0]
+        File conservative_peak_bb = glob('*conservative_peak.*.bb')[0]
+        File conservative_peak_hammock = glob('*conservative_peak.*.hammock.gz*')[0]
+        File conservative_peak_hammock_tbi = glob('*conservative_peak.*.hammock.gz*')[1]
+        File reproducibility_qc = glob('*reproducibility.qc')[0]
+        # QC metrics for optimal peak
+        File peak_region_size_qc = glob('*.peak_region_size.qc')[0]
+        File peak_region_size_plot = glob('*.peak_region_size.png')[0]
+        File num_peak_qc = glob('*.num_peak.qc')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task preseq {
-	input {
-		File? bam
-		Boolean paired_end
+    input {
+        File? bam
+        Boolean paired_end
 
-		Int mem_mb
-		String? picard_java_heap
-		File? null
-	}
-	Float picard_java_heap_factor = 0.9
+        Int mem_mb
+        String? picard_java_heap
+        File? null
+    }
+    Float picard_java_heap_factor = 0.9
 
-	command {
-		python3 $(which encode_task_preseq.py) \
-			${if paired_end then '--paired-end' else ''} \
-			${'--bam ' + bam} \
-			${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
-		${if !paired_end then 'touch null.picard_est_lib_size' else ''}
-	}
-	output {
-		File? picard_est_lib_size_qc = if paired_end then 
-			glob('*.picard_est_lib_size.qc')[0] else null
-		File preseq_plot = glob('*.preseq.png')[0]
-		File preseq_log = glob('*.preseq.log')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '${mem_mb} MB'
-		time : 1
-		disks : 'local-disk 100 HDD'
-	}
+    command {
+        python3 $(which encode_task_preseq.py) \
+            ${if paired_end then '--paired-end' else ''} \
+            ${'--bam ' + bam} \
+            ${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
+        ${if !paired_end then 'touch null.picard_est_lib_size' else ''}
+    }
+    output {
+        File? picard_est_lib_size_qc = if paired_end then 
+            glob('*.picard_est_lib_size.qc')[0] else null
+        File preseq_plot = glob('*.preseq.png')[0]
+        File preseq_log = glob('*.preseq.log')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '${mem_mb} MB'
+        time : 1
+        disks : 'local-disk 100 HDD'
+    }
 }
 
 task annot_enrich {
-	input {
-		# Fraction of Reads In Annotated Regions
-		File? ta
-		File? blacklist
-		File? dnase
-		File? prom
-		File? enh
-	}
-	command {
-		python3 $(which encode_task_annot_enrich.py) \
-			${'--ta ' + ta} \
-			${'--blacklist ' + blacklist} \
-			${'--dnase ' + dnase} \
-			${'--prom ' + prom} \
-			${'--enh ' + enh}
-	}
-	output {
-		File annot_enrich_qc = glob('*.annot_enrich.qc')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '8000 MB'
-		time : 1
-		disks : 'local-disk 100 HDD'
-	}
+    input {
+        # Fraction of Reads In Annotated Regions
+        File? ta
+        File? blacklist
+        File? dnase
+        File? prom
+        File? enh
+    }
+    command {
+        python3 $(which encode_task_annot_enrich.py) \
+            ${'--ta ' + ta} \
+            ${'--blacklist ' + blacklist} \
+            ${'--dnase ' + dnase} \
+            ${'--prom ' + prom} \
+            ${'--enh ' + enh}
+    }
+    output {
+        File annot_enrich_qc = glob('*.annot_enrich.qc')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '8000 MB'
+        time : 1
+        disks : 'local-disk 100 HDD'
+    }
 }
 
 task tss_enrich {
-	input {
-		Int? read_len
-		File? nodup_bam
-		File? tss
-		File chrsz
-	}
-	command {
-		python2 $(which encode_task_tss_enrich.py) \
-			${'--read-len ' + read_len} \
-			${'--nodup-bam ' + nodup_bam} \
-			${'--chrsz ' + chrsz} \
-			${'--tss ' + tss}
-	}
-	output {
-		File tss_plot = glob('*.tss_enrich.png')[0]
-		File tss_large_plot = glob('*.large_tss_enrich.png')[0]
-		File tss_enrich_qc = glob('*.tss_enrich.qc')[0]
-		Float tss_enrich = read_float(tss_enrich_qc)
-	}
-	runtime {
-		cpu : 1
-		memory : '8000 MB'
-		time : 1
-		disks : 'local-disk 100 HDD'
-	}
+    input {
+        Int? read_len
+        File? nodup_bam
+        File? tss
+        File chrsz
+    }
+    command {
+        python2 $(which encode_task_tss_enrich.py) \
+            ${'--read-len ' + read_len} \
+            ${'--nodup-bam ' + nodup_bam} \
+            ${'--chrsz ' + chrsz} \
+            ${'--tss ' + tss}
+    }
+    output {
+        File tss_plot = glob('*.tss_enrich.png')[0]
+        File tss_large_plot = glob('*.large_tss_enrich.png')[0]
+        File tss_enrich_qc = glob('*.tss_enrich.qc')[0]
+        Float tss_enrich = read_float(tss_enrich_qc)
+    }
+    runtime {
+        cpu : 1
+        memory : '8000 MB'
+        time : 1
+        disks : 'local-disk 100 HDD'
+    }
 }
 
 task fraglen_stat_pe {
-	# for PE only
-	input {
-		File? nodup_bam
-		String? picard_java_heap
-	}
-	Int mem_mb = 8000
-	Float picard_java_heap_factor = 0.9
+    # for PE only
+    input {
+        File? nodup_bam
+        String? picard_java_heap
+    }
+    Int mem_mb = 8000
+    Float picard_java_heap_factor = 0.9
 
-	command {
-		python3 $(which encode_task_fraglen_stat_pe.py) \
-			${'--nodup-bam ' + nodup_bam} \
-			${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
-	}
-	output {
-		File nucleosomal_qc = glob('*nucleosomal.qc')[0]
-		File fraglen_dist_plot = glob('*fraglen_dist.png')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '${mem_mb} MB'
-		time : 6
-		disks : 'local-disk 100 HDD'
-	}
+    command {
+        python3 $(which encode_task_fraglen_stat_pe.py) \
+            ${'--nodup-bam ' + nodup_bam} \
+            ${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
+    }
+    output {
+        File nucleosomal_qc = glob('*nucleosomal.qc')[0]
+        File fraglen_dist_plot = glob('*fraglen_dist.png')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '${mem_mb} MB'
+        time : 6
+        disks : 'local-disk 100 HDD'
+    }
 }
 
 task gc_bias {
-	input {
-		File? nodup_bam
-		File ref_fa
+    input {
+        File? nodup_bam
+        File ref_fa
 
-		String? picard_java_heap
-	}
-	Int mem_mb = 10000
-	Float picard_java_heap_factor = 0.9
+        String? picard_java_heap
+    }
+    Int mem_mb = 10000
+    Float picard_java_heap_factor = 0.9
 
-	command {
-		python3 $(which encode_task_gc_bias.py) \
-			${'--nodup-bam ' + nodup_bam} \
-			${'--ref-fa ' + ref_fa} \
-			${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
-	}
-	output {
-		File gc_plot = glob('*.gc_plot.png')[0]
-		File gc_log = glob('*.gc.txt')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '${mem_mb} MB'
-		time : 6
-		disks : 'local-disk 100 HDD'
-	}
+    command {
+        python3 $(which encode_task_gc_bias.py) \
+            ${'--nodup-bam ' + nodup_bam} \
+            ${'--ref-fa ' + ref_fa} \
+            ${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
+    }
+    output {
+        File gc_plot = glob('*.gc_plot.png')[0]
+        File gc_log = glob('*.gc.txt')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '${mem_mb} MB'
+        time : 6
+        disks : 'local-disk 100 HDD'
+    }
 }
 
 task compare_signal_to_roadmap {
-	input {
-		File? pval_bw
-		File? dnase
-		File? reg2map_bed
-		File? reg2map
-		File? roadmap_meta
-	}
-	command {
-		python3 $(which encode_task_compare_signal_to_roadmap.py) \
-			${'--bigwig ' + pval_bw} \
-			${'--dnase ' + dnase} \
-			${'--reg2map-bed ' + reg2map_bed} \
-			${'--reg2map ' + reg2map} \
-			${'--roadmap-meta ' + roadmap_meta}
-	}
-	output {
-		File roadmap_compare_plot = glob('*roadmap_compare_plot.png')[0]
-		File roadmap_compare_log = glob('*roadmap_compare.log')[0]
-	}
-	runtime {
-		cpu : 1
-		memory : '8000 MB'
-		time : 1
-		disks : 'local-disk 100 HDD'
-	}
+    input {
+        File? pval_bw
+        File? dnase
+        File? reg2map_bed
+        File? reg2map
+        File? roadmap_meta
+    }
+    command {
+        python3 $(which encode_task_compare_signal_to_roadmap.py) \
+            ${'--bigwig ' + pval_bw} \
+            ${'--dnase ' + dnase} \
+            ${'--reg2map-bed ' + reg2map_bed} \
+            ${'--reg2map ' + reg2map} \
+            ${'--roadmap-meta ' + roadmap_meta}
+    }
+    output {
+        File roadmap_compare_plot = glob('*roadmap_compare_plot.png')[0]
+        File roadmap_compare_log = glob('*roadmap_compare.log')[0]
+    }
+    runtime {
+        cpu : 1
+        memory : '8000 MB'
+        time : 1
+        disks : 'local-disk 100 HDD'
+    }
 }
 
 # gather all outputs and generate 
-# - qc.html		: organized final HTML report
-# - qc.json		: all QCs
+# - qc.html        : organized final HTML report
+# - qc.json        : all QCs
 task qc_report {
-	input {
-		String pipeline_ver
-		String title
-		String description
-		String? genome
-		# workflow params
-		Int multimapping
-		Array[Boolean] paired_ends
-		String pipeline_type
-		String aligner
-		String peak_caller
-		Int cap_num_peak
-		Float idr_thresh
-		Float pval_thresh
-		Int xcor_subsample_reads
-		# QCs
-		Array[File] frac_mito_qcs
-		Array[File] samstat_qcs
-		Array[File] nodup_samstat_qcs
-		Array[File] dup_qcs
-		Array[File] lib_complexity_qcs
-		Array[File] xcor_plots
-		Array[File] xcor_scores
-		File? jsd_plot
-		Array[File]? jsd_qcs
-		Array[File] idr_plots
-		Array[File]? idr_plots_pr
-		File? idr_plot_ppr
-		Array[File] frip_qcs
-		Array[File] frip_qcs_pr1
-		Array[File] frip_qcs_pr2
-		File? frip_qc_pooled
-		File? frip_qc_ppr1
-		File? frip_qc_ppr2
-		Array[File] frip_idr_qcs
-		Array[File]? frip_idr_qcs_pr
-		File? frip_idr_qc_ppr
-		Array[File] frip_overlap_qcs
-		Array[File]? frip_overlap_qcs_pr
-		File? frip_overlap_qc_ppr
-		File? idr_reproducibility_qc
-		File? overlap_reproducibility_qc
+    input {
+        String pipeline_ver
+        String title
+        String description
+        String? genome
+        # workflow params
+        Int multimapping
+        Array[Boolean] paired_ends
+        String pipeline_type
+        String aligner
+        String peak_caller
+        Int cap_num_peak
+        Float idr_thresh
+        Float pval_thresh
+        Int xcor_subsample_reads
+        # QCs
+        Array[File] frac_mito_qcs
+        Array[File] samstat_qcs
+        Array[File] nodup_samstat_qcs
+        Array[File] dup_qcs
+        Array[File] lib_complexity_qcs
+        Array[File] xcor_plots
+        Array[File] xcor_scores
+        File? jsd_plot
+        Array[File]? jsd_qcs
+        Array[File] idr_plots
+        Array[File]? idr_plots_pr
+        File? idr_plot_ppr
+        Array[File] frip_qcs
+        Array[File] frip_qcs_pr1
+        Array[File] frip_qcs_pr2
+        File? frip_qc_pooled
+        File? frip_qc_ppr1
+        File? frip_qc_ppr2
+        Array[File] frip_idr_qcs
+        Array[File]? frip_idr_qcs_pr
+        File? frip_idr_qc_ppr
+        Array[File] frip_overlap_qcs
+        Array[File]? frip_overlap_qcs_pr
+        File? frip_overlap_qc_ppr
+        File? idr_reproducibility_qc
+        File? overlap_reproducibility_qc
 
-		Array[File] annot_enrich_qcs
-		Array[File] tss_enrich_qcs
-		Array[File] tss_large_plots
-		Array[File] roadmap_compare_plots
-		Array[File] fraglen_dist_plots
-		Array[File] fraglen_nucleosomal_qcs
-		Array[File] gc_plots
-		Array[File] preseq_plots
-		Array[File] picard_est_lib_size_qcs
+        Array[File] annot_enrich_qcs
+        Array[File] tss_enrich_qcs
+        Array[File] tss_large_plots
+        Array[File] roadmap_compare_plots
+        Array[File] fraglen_dist_plots
+        Array[File] fraglen_nucleosomal_qcs
+        Array[File] gc_plots
+        Array[File] preseq_plots
+        Array[File] picard_est_lib_size_qcs
 
-		Array[File] peak_region_size_qcs
-		Array[File] peak_region_size_plots
-		Array[File] num_peak_qcs
+        Array[File] peak_region_size_qcs
+        Array[File] peak_region_size_plots
+        Array[File] num_peak_qcs
 
-		File? idr_opt_peak_region_size_qc
-		File? idr_opt_peak_region_size_plot
-		File? idr_opt_num_peak_qc
+        File? idr_opt_peak_region_size_qc
+        File? idr_opt_peak_region_size_plot
+        File? idr_opt_num_peak_qc
 
-		File? overlap_opt_peak_region_size_qc
-		File? overlap_opt_peak_region_size_plot
-		File? overlap_opt_num_peak_qc
+        File? overlap_opt_peak_region_size_qc
+        File? overlap_opt_peak_region_size_plot
+        File? overlap_opt_num_peak_qc
 
-		File? qc_json_ref
-	}
-	command {
-		python3 $(which encode_task_qc_report.py) \
-			${'--pipeline-ver ' + pipeline_ver} \
-			${"--title '" + sub(title,"'","_") + "'"} \
-			${"--desc '" + sub(description,"'","_") + "'"} \
-			${'--genome ' + genome} \
-			${'--multimapping ' + multimapping} \
-			--paired-ends ${sep=' ' paired_ends} \
-			--pipeline-type ${pipeline_type} \
-			--aligner ${aligner} \
-			--peak-caller ${peak_caller} \
-			${'--cap-num-peak ' + cap_num_peak} \
-			--idr-thresh ${idr_thresh} \
-			--pval-thresh ${pval_thresh} \
-			--xcor-subsample-reads ${xcor_subsample_reads} \
-			--frac-mito-qcs ${sep='_:_' frac_mito_qcs} \
-			--samstat-qcs ${sep='_:_' samstat_qcs} \
-			--nodup-samstat-qcs ${sep='_:_' nodup_samstat_qcs} \
-			--dup-qcs ${sep='_:_' dup_qcs} \
-			--lib-complexity-qcs ${sep='_:_' lib_complexity_qcs} \
-			--xcor-plots ${sep='_:_' xcor_plots} \
-			--xcor-scores ${sep='_:_' xcor_scores} \
-			--idr-plots ${sep='_:_' idr_plots} \
-			--idr-plots-pr ${sep='_:_' idr_plots_pr} \
-			${'--jsd-plot ' + jsd_plot} \
-			--jsd-qcs ${sep='_:_' jsd_qcs} \
-			${'--idr-plot-ppr ' + idr_plot_ppr} \
-			--frip-qcs ${sep='_:_' frip_qcs} \
-			--frip-qcs-pr1 ${sep='_:_' frip_qcs_pr1} \
-			--frip-qcs-pr2 ${sep='_:_' frip_qcs_pr2} \
-			${'--frip-qc-pooled ' + frip_qc_pooled} \
-			${'--frip-qc-ppr1 ' + frip_qc_ppr1} \
-			${'--frip-qc-ppr2 ' + frip_qc_ppr2} \
-			--frip-idr-qcs ${sep='_:_' frip_idr_qcs} \
-			--frip-idr-qcs-pr ${sep='_:_' frip_idr_qcs_pr} \
-			${'--frip-idr-qc-ppr ' + frip_idr_qc_ppr} \
-			--frip-overlap-qcs ${sep='_:_' frip_overlap_qcs} \
-			--frip-overlap-qcs-pr ${sep='_:_' frip_overlap_qcs_pr} \
-			${'--frip-overlap-qc-ppr ' + frip_overlap_qc_ppr} \
-			${'--idr-reproducibility-qc ' + idr_reproducibility_qc} \
-			${'--overlap-reproducibility-qc ' + overlap_reproducibility_qc} \
-			--annot-enrich-qcs ${sep='_:_' annot_enrich_qcs} \
-			--tss-enrich-qcs ${sep='_:_' tss_enrich_qcs} \
-			--tss-large-plots ${sep='_:_' tss_large_plots} \
-			--roadmap-compare-plots ${sep='_:_' roadmap_compare_plots} \
-			--fraglen-dist-plots ${sep='_:_' fraglen_dist_plots} \
-			--fraglen-nucleosomal-qcs ${sep='_:_' fraglen_nucleosomal_qcs} \
-			--gc-plots ${sep='_:_' gc_plots} \
-			--preseq-plots ${sep='_:_' preseq_plots} \
-			--picard-est-lib-size-qcs ${sep='_:_' picard_est_lib_size_qcs} \
-			--peak-region-size-qcs ${sep='_:_' peak_region_size_qcs} \
-			--peak-region-size-plots ${sep='_:_' peak_region_size_plots} \
-			--num-peak-qcs ${sep='_:_' num_peak_qcs} \
-			${'--idr-opt-peak-region-size-qc ' + idr_opt_peak_region_size_qc} \
-			${'--idr-opt-peak-region-size-plot ' + idr_opt_peak_region_size_plot} \
-			${'--idr-opt-num-peak-qc ' + idr_opt_num_peak_qc} \
-			${'--overlap-opt-peak-region-size-qc ' + overlap_opt_peak_region_size_qc} \
-			${'--overlap-opt-peak-region-size-plot ' + overlap_opt_peak_region_size_plot} \
-			${'--overlap-opt-num-peak-qc ' + overlap_opt_num_peak_qc} \
-			--out-qc-html qc.html \
-			--out-qc-json qc.json \
-			${'--qc-json-ref ' + qc_json_ref}
-	}
-	output {
-		File report = glob('*qc.html')[0]
-		File qc_json = glob('*qc.json')[0]
-		Boolean qc_json_ref_match = read_string('qc_json_ref_match.txt')=='True'
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'		
-	}
+        File? qc_json_ref
+    }
+    command {
+        python3 $(which encode_task_qc_report.py) \
+            ${'--pipeline-ver ' + pipeline_ver} \
+            ${"--title '" + sub(title,"'","_") + "'"} \
+            ${"--desc '" + sub(description,"'","_") + "'"} \
+            ${'--genome ' + genome} \
+            ${'--multimapping ' + multimapping} \
+            --paired-ends ${sep=' ' paired_ends} \
+            --pipeline-type ${pipeline_type} \
+            --aligner ${aligner} \
+            --peak-caller ${peak_caller} \
+            ${'--cap-num-peak ' + cap_num_peak} \
+            --idr-thresh ${idr_thresh} \
+            --pval-thresh ${pval_thresh} \
+            --xcor-subsample-reads ${xcor_subsample_reads} \
+            --frac-mito-qcs ${sep='_:_' frac_mito_qcs} \
+            --samstat-qcs ${sep='_:_' samstat_qcs} \
+            --nodup-samstat-qcs ${sep='_:_' nodup_samstat_qcs} \
+            --dup-qcs ${sep='_:_' dup_qcs} \
+            --lib-complexity-qcs ${sep='_:_' lib_complexity_qcs} \
+            --xcor-plots ${sep='_:_' xcor_plots} \
+            --xcor-scores ${sep='_:_' xcor_scores} \
+            --idr-plots ${sep='_:_' idr_plots} \
+            --idr-plots-pr ${sep='_:_' idr_plots_pr} \
+            ${'--jsd-plot ' + jsd_plot} \
+            --jsd-qcs ${sep='_:_' jsd_qcs} \
+            ${'--idr-plot-ppr ' + idr_plot_ppr} \
+            --frip-qcs ${sep='_:_' frip_qcs} \
+            --frip-qcs-pr1 ${sep='_:_' frip_qcs_pr1} \
+            --frip-qcs-pr2 ${sep='_:_' frip_qcs_pr2} \
+            ${'--frip-qc-pooled ' + frip_qc_pooled} \
+            ${'--frip-qc-ppr1 ' + frip_qc_ppr1} \
+            ${'--frip-qc-ppr2 ' + frip_qc_ppr2} \
+            --frip-idr-qcs ${sep='_:_' frip_idr_qcs} \
+            --frip-idr-qcs-pr ${sep='_:_' frip_idr_qcs_pr} \
+            ${'--frip-idr-qc-ppr ' + frip_idr_qc_ppr} \
+            --frip-overlap-qcs ${sep='_:_' frip_overlap_qcs} \
+            --frip-overlap-qcs-pr ${sep='_:_' frip_overlap_qcs_pr} \
+            ${'--frip-overlap-qc-ppr ' + frip_overlap_qc_ppr} \
+            ${'--idr-reproducibility-qc ' + idr_reproducibility_qc} \
+            ${'--overlap-reproducibility-qc ' + overlap_reproducibility_qc} \
+            --annot-enrich-qcs ${sep='_:_' annot_enrich_qcs} \
+            --tss-enrich-qcs ${sep='_:_' tss_enrich_qcs} \
+            --tss-large-plots ${sep='_:_' tss_large_plots} \
+            --roadmap-compare-plots ${sep='_:_' roadmap_compare_plots} \
+            --fraglen-dist-plots ${sep='_:_' fraglen_dist_plots} \
+            --fraglen-nucleosomal-qcs ${sep='_:_' fraglen_nucleosomal_qcs} \
+            --gc-plots ${sep='_:_' gc_plots} \
+            --preseq-plots ${sep='_:_' preseq_plots} \
+            --picard-est-lib-size-qcs ${sep='_:_' picard_est_lib_size_qcs} \
+            --peak-region-size-qcs ${sep='_:_' peak_region_size_qcs} \
+            --peak-region-size-plots ${sep='_:_' peak_region_size_plots} \
+            --num-peak-qcs ${sep='_:_' num_peak_qcs} \
+            ${'--idr-opt-peak-region-size-qc ' + idr_opt_peak_region_size_qc} \
+            ${'--idr-opt-peak-region-size-plot ' + idr_opt_peak_region_size_plot} \
+            ${'--idr-opt-num-peak-qc ' + idr_opt_num_peak_qc} \
+            ${'--overlap-opt-peak-region-size-qc ' + overlap_opt_peak_region_size_qc} \
+            ${'--overlap-opt-peak-region-size-plot ' + overlap_opt_peak_region_size_plot} \
+            ${'--overlap-opt-num-peak-qc ' + overlap_opt_num_peak_qc} \
+            --out-qc-html qc.html \
+            --out-qc-json qc.json \
+            ${'--qc-json-ref ' + qc_json_ref}
+    }
+    output {
+        File report = glob('*qc.html')[0]
+        File qc_json = glob('*qc.json')[0]
+        Boolean qc_json_ref_match = read_string('qc_json_ref_match.txt')=='True'
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task read_genome_tsv {
-	input {
-		File? genome_tsv
-		String? null_s
-	}
-	command <<<
-		echo "$(basename ~{genome_tsv})" > genome_name
-		# create empty files for all entries
-		touch ref_fa bowtie2_idx_tar chrsz gensz blacklist blacklist2
-		touch ref_mito_fa
-		touch bowtie2_mito_idx_tar
-		touch tss tss_enrich # for backward compatibility
-		touch dnase prom enh reg2map reg2map_bed roadmap_meta
-		touch mito_chr_name
-		touch regex_bfilt_peak_chr_name
+    input {
+        File? genome_tsv
+        String? null_s
+    }
+    command <<<
+        echo "$(basename ~{genome_tsv})" > genome_name
+        # create empty files for all entries
+        touch ref_fa bowtie2_idx_tar chrsz gensz blacklist blacklist2
+        touch ref_mito_fa
+        touch bowtie2_mito_idx_tar
+        touch tss tss_enrich # for backward compatibility
+        touch dnase prom enh reg2map reg2map_bed roadmap_meta
+        touch mito_chr_name
+        touch regex_bfilt_peak_chr_name
 
-		python <<CODE
-		import os
-		with open('~{genome_tsv}','r') as fp:
-			for line in fp:
-				arr = line.strip('\n').split('\t')
-				if arr:
-					key, val = arr
-					with open(key,'w') as fp2:
-						fp2.write(val)
-		CODE
-	>>>
-	output {
-		String? genome_name = read_string('genome_name')
-		String? ref_fa = if size('ref_fa')==0 then null_s else read_string('ref_fa')
-		String? ref_mito_fa = if size('ref_mito_fa')==0 then null_s else read_string('ref_mito_fa')
-		String? bowtie2_idx_tar = if size('bowtie2_idx_tar')==0 then null_s else read_string('bowtie2_idx_tar')
-		String? bowtie2_mito_idx_tar = if size('bowtie2_mito_idx_tar')==0 then null_s else read_string('bowtie2_mito_idx_tar')
-		String? chrsz = if size('chrsz')==0 then null_s else read_string('chrsz')
-		String? gensz = if size('gensz')==0 then null_s else read_string('gensz')
-		String? blacklist = if size('blacklist')==0 then null_s else read_string('blacklist')
-		String? blacklist2 = if size('blacklist2')==0 then null_s else read_string('blacklist2')
-		String? mito_chr_name = if size('mito_chr_name')==0 then null_s else read_string('mito_chr_name')
-		String? regex_bfilt_peak_chr_name = if size('regex_bfilt_peak_chr_name')==0 then 'chr[\\dXY]+'
-			else read_string('regex_bfilt_peak_chr_name')
-		String? tss = if size('tss')!=0 then read_string('tss')
-			else if size('tss_enrich')!=0 then read_string('tss_enrich') else null_s
-		String? dnase = if size('dnase')==0 then null_s else read_string('dnase')
-		String? prom = if size('prom')==0 then null_s else read_string('prom')
-		String? enh = if size('enh')==0 then null_s else read_string('enh')
-		String? reg2map = if size('reg2map')==0 then null_s else read_string('reg2map')
-		String? reg2map_bed = if size('reg2map_bed')==0 then null_s else read_string('reg2map_bed')
-		String? roadmap_meta = if size('roadmap_meta')==0 then null_s else read_string('roadmap_meta')
-	}
-	runtime {
-		maxRetries : 0
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'		
-	}
+        python <<CODE
+        import os
+        with open('~{genome_tsv}','r') as fp:
+            for line in fp:
+                arr = line.strip('\n').split('\t')
+                if arr:
+                    key, val = arr
+                    with open(key,'w') as fp2:
+                        fp2.write(val)
+        CODE
+    >>>
+    output {
+        String? genome_name = read_string('genome_name')
+        String? ref_fa = if size('ref_fa')==0 then null_s else read_string('ref_fa')
+        String? ref_mito_fa = if size('ref_mito_fa')==0 then null_s else read_string('ref_mito_fa')
+        String? bowtie2_idx_tar = if size('bowtie2_idx_tar')==0 then null_s else read_string('bowtie2_idx_tar')
+        String? bowtie2_mito_idx_tar = if size('bowtie2_mito_idx_tar')==0 then null_s else read_string('bowtie2_mito_idx_tar')
+        String? chrsz = if size('chrsz')==0 then null_s else read_string('chrsz')
+        String? gensz = if size('gensz')==0 then null_s else read_string('gensz')
+        String? blacklist = if size('blacklist')==0 then null_s else read_string('blacklist')
+        String? blacklist2 = if size('blacklist2')==0 then null_s else read_string('blacklist2')
+        String? mito_chr_name = if size('mito_chr_name')==0 then null_s else read_string('mito_chr_name')
+        String? regex_bfilt_peak_chr_name = if size('regex_bfilt_peak_chr_name')==0 then 'chr[\\dXY]+'
+            else read_string('regex_bfilt_peak_chr_name')
+        String? tss = if size('tss')!=0 then read_string('tss')
+            else if size('tss_enrich')!=0 then read_string('tss_enrich') else null_s
+        String? dnase = if size('dnase')==0 then null_s else read_string('dnase')
+        String? prom = if size('prom')==0 then null_s else read_string('prom')
+        String? enh = if size('enh')==0 then null_s else read_string('enh')
+        String? reg2map = if size('reg2map')==0 then null_s else read_string('reg2map')
+        String? reg2map_bed = if size('reg2map_bed')==0 then null_s else read_string('reg2map_bed')
+        String? roadmap_meta = if size('roadmap_meta')==0 then null_s else read_string('roadmap_meta')
+    }
+    runtime {
+        maxRetries : 0
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }
 
 task raise_exception {
-	input {
-		String msg
-	}
-	command {
-		echo -e "\n* Error: ${msg}\n" >&2
-		exit 2
-	}
-	output {
-		String error_msg = '${msg}'
-	}
-	runtime {
-		maxRetries : 0
-	}
+    input {
+        String msg
+    }
+    command {
+        echo -e "\n* Error: ${msg}\n" >&2
+        exit 2
+    }
+    output {
+        String error_msg = '${msg}'
+    }
+    runtime {
+        maxRetries : 0
+    }
 }

--- a/atac.wdl
+++ b/atac.wdl
@@ -1718,6 +1718,7 @@ task frac_mito {
     }
 
     command {
+        set -e
         python3 $(which encode_task_frac_mito.py) \
             ${non_mito_samstat} ${mito_samstat}
     }
@@ -1754,6 +1755,7 @@ task filter {
     Float picard_java_heap_factor = 0.9
 
     command {
+        set -e
         python3 $(which encode_task_filter.py) \
             ${bam} \
             ${if paired_end then '--paired-end' else ''} \
@@ -1797,6 +1799,7 @@ task bam2ta {
     }
 
     command {
+        set -e
         python3 $(which encode_task_bam2ta.py) \
             ${bam} \
             ${if paired_end then '--paired-end' else ''} \
@@ -1826,6 +1829,7 @@ task spr {
     }
 
     command {
+        set -e
         python3 $(which encode_task_spr.py) \
             ${ta} \
             ${if paired_end then '--paired-end' else ''}
@@ -1849,6 +1853,7 @@ task pool_ta {
         String? prefix         # basename prefix
     }
     command {
+        set -e
         python3 $(which encode_task_pool_ta.py) \
             ${sep=' ' select_all(tas)} \
             ${'--prefix ' + prefix} \
@@ -1880,6 +1885,7 @@ task xcor {
     }
 
     command {
+        set -e
         python3 $(which encode_task_xcor.py) \
             ${ta} \
             ${if paired_end then '--paired-end' else ''} \
@@ -1914,6 +1920,7 @@ task jsd {
     }
 
     command {
+        set -e
         python3 $(which encode_task_jsd.py) \
             ${sep=' ' select_all(nodup_bams)} \
             ${'--mapq-thresh '+ mapq_thresh} \
@@ -1938,6 +1945,7 @@ task count_signal_track {
         File chrsz            # 2-col chromosome sizes file
     }
     command {
+        set -e
         python3 $(which encode_task_count_signal_track.py) \
             ${ta} \
             ${'--chrsz ' + chrsz}
@@ -2030,6 +2038,7 @@ task macs2_signal_track {
         String disks
     }
     command {
+        set -e
         python3 $(which encode_task_macs2_signal_track_atac.py) \
             ${ta} \
             ${'--gensz '+ gensz} \
@@ -2066,7 +2075,7 @@ task idr {
         String rank
     }
     command {
-        ${if defined(ta) then '' else 'touch null.frip.qc'}
+        set -e
         touch null
         python3 $(which encode_task_idr.py) \
             ${peak1} ${peak2} ${peak_pooled} \
@@ -2111,7 +2120,7 @@ task overlap {
         String peak_type
     }
     command {
-        ${if defined(ta) then '' else 'touch null.frip.qc'}
+        set -e
         touch null 
         python3 $(which encode_task_overlap.py) \
             ${peak1} ${peak2} ${peak_pooled} \
@@ -2152,6 +2161,7 @@ task reproducibility {
         File chrsz            # 2-col chromosome sizes file
     }
     command {
+        set -e
         python3 $(which encode_task_reproducibility.py) \
             ${sep=' ' peaks} \
             --peaks-pr ${sep=' ' peaks_pr} \
@@ -2195,6 +2205,7 @@ task preseq {
     Float picard_java_heap_factor = 0.9
 
     command {
+        set -e
         python3 $(which encode_task_preseq.py) \
             ${if paired_end then '--paired-end' else ''} \
             ${'--bam ' + bam} \
@@ -2225,6 +2236,7 @@ task annot_enrich {
         File? enh
     }
     command {
+        set -e
         python3 $(which encode_task_annot_enrich.py) \
             ${'--ta ' + ta} \
             ${'--blacklist ' + blacklist} \
@@ -2251,6 +2263,7 @@ task tss_enrich {
         File chrsz
     }
     command {
+        set -e
         python2 $(which encode_task_tss_enrich.py) \
             ${'--read-len ' + read_len} \
             ${'--nodup-bam ' + nodup_bam} \
@@ -2281,6 +2294,7 @@ task fraglen_stat_pe {
     Float picard_java_heap_factor = 0.9
 
     command {
+        set -e
         python3 $(which encode_task_fraglen_stat_pe.py) \
             ${'--nodup-bam ' + nodup_bam} \
             ${'--picard-java-heap ' + if defined(picard_java_heap) then picard_java_heap else (round(mem_mb * picard_java_heap_factor) + 'M')}
@@ -2308,6 +2322,7 @@ task gc_bias {
     Float picard_java_heap_factor = 0.9
 
     command {
+        set -e
         python3 $(which encode_task_gc_bias.py) \
             ${'--nodup-bam ' + nodup_bam} \
             ${'--ref-fa ' + ref_fa} \
@@ -2334,6 +2349,7 @@ task compare_signal_to_roadmap {
         File? roadmap_meta
     }
     command {
+        set -e
         python3 $(which encode_task_compare_signal_to_roadmap.py) \
             ${'--bigwig ' + pval_bw} \
             ${'--dnase ' + dnase} \
@@ -2425,6 +2441,7 @@ task qc_report {
         File? qc_json_ref
     }
     command {
+        set -e
         python3 $(which encode_task_qc_report.py) \
             ${'--pipeline-ver ' + pipeline_ver} \
             ${"--title '" + sub(title,"'","_") + "'"} \

--- a/atac.wdl
+++ b/atac.wdl
@@ -278,7 +278,7 @@ workflow atac {
             help: 'Define if you want to start pipeline from FASTQs files. Pipeline can start from any type of inputs (e.g. FASTQs, BAMs, ...). Choose one type and fill paramters for that type and leave other undefined. Especially for FASTQs, we have individual variable for each biological replicate to allow FASTQs of technical replicates can be merged. Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep1_R2). These FASTQs are usually technical replicates to be merged.'
         }
         fastqs_rep1_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            description: 'Read2 FASTQs to be merged for a biological replicate 1.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep1_R1). These FASTQs are usually technical replicates to be merged.'
         }
@@ -288,7 +288,7 @@ workflow atac {
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep2_R2). These FASTQs are usually technical replicates to be merged.'
         }
         fastqs_rep2_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 2.',
+            description: 'Read2 FASTQs to be merged for a biological replicate 2.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep2_R1). These FASTQs are usually technical replicates to be merged.'
         }
@@ -298,7 +298,7 @@ workflow atac {
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep3_R2). These FASTQs are usually technical replicates to be merged.'
         }
         fastqs_rep3_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 3.',
+            description: 'Read2 FASTQs to be merged for a biological replicate 3.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep3_R1). These FASTQs are usually technical replicates to be merged.'
         }
@@ -308,7 +308,7 @@ workflow atac {
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep4_R2). These FASTQs are usually technical replicates to be merged.'
         }
         fastqs_rep4_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 4.',
+            description: 'Read2 FASTQs to be merged for a biological replicate 4.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep4_R1). These FASTQs are usually technical replicates to be merged.'
         }
@@ -318,7 +318,7 @@ workflow atac {
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep5_R2). These FASTQs are usually technical replicates to be merged.'
         }
         fastqs_rep5_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 5.',
+            description: 'Read2 FASTQs to be merged for a biological replicate 5.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep5_R1). These FASTQs are usually technical replicates to be merged.'
         }
@@ -328,7 +328,7 @@ workflow atac {
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep6_R2). These FASTQs are usually technical replicates to be merged.'
         }
         fastqs_rep6_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 6.',
+            description: 'Read2 FASTQs to be merged for a biological replicate 6.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep6_R1). These FASTQs are usually technical replicates to be merged.'
         }
@@ -338,7 +338,7 @@ workflow atac {
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep7_R2). These FASTQs are usually technical replicates to be merged.'
         }
         fastqs_rep7_R2: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 7.',
+            description: 'Read2 FASTQs to be merged for a biological replicate 7.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep7_R1). These FASTQs are usually technical replicates to be merged.'
         }
@@ -348,7 +348,7 @@ workflow atac {
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep8_R2). These FASTQs are usually technical replicates to be merged.'
         }
         fastqs_rep8_R2: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 8.',
+            description: 'Read2 FASTQs to be merged for a biological replicate 8.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep8_R1). These FASTQs are usually technical replicates to be merged.'
         }
@@ -358,7 +358,7 @@ workflow atac {
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep9_R2). These FASTQs are usually technical replicates to be merged.'
         }
         fastqs_rep9_R2: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 9.',
+            description: 'Read2 FASTQs to be merged for a biological replicate 9.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep9_R1). These FASTQs are usually technical replicates to be merged.'
         }
@@ -368,7 +368,7 @@ workflow atac {
             help: 'Make sure that they are consistent with read2 FASTQs (atac.fastqs_rep10_R2). These FASTQs are usually technical replicates to be merged.'
         }
         fastqs_rep10_R2: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 10.',
+            description: 'Read2 FASTQs to be merged for a biological replicate 10.',
             group: 'input_genomic_data',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.fastqs_rep10_R1). These FASTQs are usually technical replicates to be merged.'
         }
@@ -501,92 +501,92 @@ workflow atac {
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep1_R1).'
         }
         adapters_rep2_R1: {
-            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 2.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep2_R2).'
         }
         adapters_rep2_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 2.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep2_R1).'
         }
         adapters_rep3_R1: {
-            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 3.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep3_R2).'
         }
         adapters_rep3_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 3.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep3_R1).'
         }
         adapters_rep4_R1: {
-            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 4.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep4_R2).'
         }
         adapters_rep4_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 4.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep4_R1).'
         }
         adapters_rep5_R1: {
-            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 5.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep5_R2).'
         }
         adapters_rep5_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 5.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep5_R1).'
         }
         adapters_rep6_R1: {
-            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 6.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep6_R2).'
         }
         adapters_rep6_R1: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 6.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep6_R1).'
         }
         adapters_rep7_R1: {
-            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 7.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep7_R2).'
         }
         adapters_rep7_R2: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 7.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep7_R1).'
         }
         adapters_rep8_R1: {
-            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 8.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep8_R2).'
         }
         adapters_rep8_R2: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 8.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep8_R1).'
         }
         adapters_rep9_R1: {
-            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 9.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep9_R2).'
         }
         adapters_rep9_R2: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 9.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep9_R1).'
         }
         adapters_rep10_R1: {
-            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read1 FASTQs to be merged for a biological replicate 10.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read2 FASTQs (atac.adapters_rep10_R2).'
         }
         adapters_rep10_R2: {
-            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 1.',
+            description: 'Adapter sequences for read2 FASTQs to be merged for a biological replicate 10.',
             group: 'adapter_trimming',
             help: 'Make sure that they are consistent with read1 FASTQs (atac.adapters_rep10_R1).'
         }

--- a/dev/build_on_dx_dockerhub.sh
+++ b/dev/build_on_dx_dockerhub.sh
@@ -8,69 +8,79 @@ DXWDL=~/dxWDL-v1.46.4.jar
 # check if docker image exists on dockerhub
 docker pull $DOCKER
 
+# make a copy of WDL
+# workflows generated from original WDL cannot start from inputs other than FASTQs
+# make all vars non-optional (without ?)
+cp atac.wdl atac.dx.wdl
+sed -i 's/Array\[File?\] bams = \[\]/Array\[File\] bams = \[\]/g' atac.dx.wdl
+sed -i 's/Array\[File?\] nodup_bams = \[\]/Array\[File\] nodup_bams = \[\]/g' atac.dx.wdl
+sed -i 's/Array\[File?\] tas = \[\]/Array\[File\] tas = \[\]/g' atac.dx.wdl
+
 # general
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/general -defaults example_input_json/dx/template_general.json
 
 # hg38
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/hg38 -defaults example_input_json/dx/template_hg38.json
 
 # hg19
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/hg19 -defaults example_input_json/dx/template_hg19.json
 
 # mm10
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/mm10 -defaults example_input_json/dx/template_mm10.json
 
 # mm9
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/mm9 -defaults example_input_json/dx/template_mm9.json
 
 # test sample
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled -defaults example_input_json/dx/ENCSR356KRQ_subsampled_dx.json
 
 # test sample (single rep)
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled_rep1 -defaults example_input_json/dx/ENCSR356KRQ_subsampled_rep1_dx.json
 
 ## DX Azure
 
 # general
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/general -defaults example_input_json/dx_azure/template_general.json
 
 # hg38
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/hg38 -defaults example_input_json/dx_azure/template_hg38.json
 
 # hg19
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/hg19 -defaults example_input_json/dx_azure/template_hg19.json
 
 # mm10
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/mm10 -defaults example_input_json/dx_azure/template_mm10.json
 
 # mm9
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/mm9 -defaults example_input_json/dx_azure/template_mm9.json
 
 # test sample
-java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled -defaults example_input_json/dx_azure/ENCSR356KRQ_subsampled_dx_azure.json
+
+rm -f atac.dx.wdl

--- a/dev/build_on_dx_dockerhub.sh
+++ b/dev/build_on_dx_dockerhub.sh
@@ -1,59 +1,77 @@
 #!/bin/bash
 set -e
 
-VER=$(cat atac.wdl | grep "#CAPER docker" | awk 'BEGIN{FS=":"} {print $2}')
+VER=$(cat atac.wdl | grep "String pipeline_ver = " | awk '{gsub("'"'"'",""); print $4}')
 DOCKER=encodedcc/atac-seq-pipeline:$VER
 
 # check if docker image exists on dockerhub
 docker pull $DOCKER
 
-# make a copy of WDL
-# workflows generated from original WDL cannot start from inputs other than FASTQs
-# make all vars non-optional (without ?)
-cp atac.wdl atac.dx.wdl
-sed -i 's/Array\[File?\] bams = \[\]/Array\[File\] bams = \[\]/g' atac.dx.wdl
-sed -i 's/Array\[File?\] nodup_bams = \[\]/Array\[File\] nodup_bams = \[\]/g' atac.dx.wdl
-sed -i 's/Array\[File?\] tas = \[\]/Array\[File\] tas = \[\]/g' atac.dx.wdl
-
 # general
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/general -defaults example_input_json/dx/template_general.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/general -defaults example_input_json/dx/template_general.json
 
 # hg38
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/hg38 -defaults example_input_json/dx/template_hg38.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/hg38 -defaults example_input_json/dx/template_hg38.json
 
 # hg19
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/hg19 -defaults example_input_json/dx/template_hg19.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/hg19 -defaults example_input_json/dx/template_hg19.json
 
 # mm10
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/mm10 -defaults example_input_json/dx/template_mm10.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/mm10 -defaults example_input_json/dx/template_mm10.json
 
 # mm9
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/mm9 -defaults example_input_json/dx/template_mm9.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/mm9 -defaults example_input_json/dx/template_mm9.json
 
 # test sample
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled -defaults example_input_json/dx/ENCSR356KRQ_subsampled_dx.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled -defaults example_input_json/dx/ENCSR356KRQ_subsampled_dx.json
 
 # test sample (single rep)
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled_rep1 -defaults example_input_json/dx/ENCSR356KRQ_subsampled_rep1_dx.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled_rep1 -defaults example_input_json/dx/ENCSR356KRQ_subsampled_rep1_dx.json
 
 ## DX Azure
 
 # general
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/general -defaults example_input_json/dx_azure/template_general.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/general -defaults example_input_json/dx_azure/template_general.json
 
 # hg38
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/hg38 -defaults example_input_json/dx_azure/template_hg38.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/hg38 -defaults example_input_json/dx_azure/template_hg38.json
 
 # hg19
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/hg19 -defaults example_input_json/dx_azure/template_hg19.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/hg19 -defaults example_input_json/dx_azure/template_hg19.json
 
 # mm10
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/mm10 -defaults example_input_json/dx_azure/template_mm10.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/mm10 -defaults example_input_json/dx_azure/template_mm10.json
 
 # mm9
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/mm9 -defaults example_input_json/dx_azure/template_mm9.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/mm9 -defaults example_input_json/dx_azure/template_mm9.json
 
 # test sample
-java -jar ~/dxWDL-0.81.6.jar compile atac.dx.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder /ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled -defaults example_input_json/dx_azure/ENCSR356KRQ_subsampled_dx_azure.json
+java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+<(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
+/ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled -defaults example_input_json/dx_azure/ENCSR356KRQ_subsampled_dx_azure.json
 
-rm -f atac.dx.wdl
+rm -f atac.wdl

--- a/dev/build_on_dx_dockerhub.sh
+++ b/dev/build_on_dx_dockerhub.sh
@@ -3,75 +3,74 @@ set -e
 
 VER=$(cat atac.wdl | grep "String pipeline_ver = " | awk '{gsub("'"'"'",""); print $4}')
 DOCKER=encodedcc/atac-seq-pipeline:$VER
+DXWDL=~/dxWDL-v1.46.4.jar
 
 # check if docker image exists on dockerhub
 docker pull $DOCKER
 
 # general
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/general -defaults example_input_json/dx/template_general.json
 
 # hg38
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/hg38 -defaults example_input_json/dx/template_hg38.json
 
 # hg19
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/hg19 -defaults example_input_json/dx/template_hg19.json
 
 # mm10
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/mm10 -defaults example_input_json/dx/template_mm10.json
 
 # mm9
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/mm9 -defaults example_input_json/dx/template_mm9.json
 
 # test sample
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled -defaults example_input_json/dx/ENCSR356KRQ_subsampled_dx.json
 
 # test sample (single rep)
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled_rep1 -defaults example_input_json/dx/ENCSR356KRQ_subsampled_rep1_dx.json
 
 ## DX Azure
 
 # general
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/general -defaults example_input_json/dx_azure/template_general.json
 
 # hg38
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/hg38 -defaults example_input_json/dx_azure/template_hg38.json
 
 # hg19
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/hg19 -defaults example_input_json/dx_azure/template_hg19.json
 
 # mm10
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/mm10 -defaults example_input_json/dx_azure/template_mm10.json
 
 # mm9
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/mm9 -defaults example_input_json/dx_azure/template_mm9.json
 
 # test sample
-java -jar ~/dxWDL-v1.46.4.jar compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
+java -jar ${DXWDL} compile atac.wdl -project "ENCODE Uniform Processing Pipelines Azure" -extras \
 <(echo "{\"default_runtime_attributes\":{\"docker\":\"${DOCKER}\"}}") -f -folder \
 /ATAC-seq/workflows/$VER/test_ENCSR356KRQ_subsampled -defaults example_input_json/dx_azure/ENCSR356KRQ_subsampled_dx_azure.json
-
-rm -f atac.wdl

--- a/dev/test/test_task/compare_md5sum.wdl
+++ b/dev/test/test_task/compare_md5sum.wdl
@@ -1,92 +1,95 @@
+version 1.0
+
 task compare_md5sum {
-	Array[String] labels
-	Array[File] files
-	Array[File] ref_files
+    input {
+        Array[String] labels
+        Array[File] files
+        Array[File] ref_files
+    }
+    command <<<
+        python <<CODE    
+        from collections import OrderedDict
+        import os
+        import json
+        import hashlib
 
-	command <<<
-		python <<CODE	
-		from collections import OrderedDict
-		import os
-		import json
-		import hashlib
+        def md5sum(filename, blocksize=65536):
+            hash = hashlib.md5()
+            with open(filename, 'rb') as f:
+                for block in iter(lambda: f.read(blocksize), b''):
+                    hash.update(block)
+            return hash.hexdigest()
 
-		def md5sum(filename, blocksize=65536):
-		    hash = hashlib.md5()
-		    with open(filename, 'rb') as f:
-		        for block in iter(lambda: f.read(blocksize), b''):
-		            hash.update(block)
-		    return hash.hexdigest()
+        with open('~{write_lines(labels)}','r') as fp:
+            labels = fp.read().splitlines()
+        with open('~{write_lines(files)}','r') as fp:
+            files = fp.read().splitlines()
+        with open('~{write_lines(ref_files)}','r') as fp:
+            ref_files = fp.read().splitlines()
 
-		with open('${write_lines(labels)}','r') as fp:
-			labels = fp.read().splitlines()
-		with open('${write_lines(files)}','r') as fp:
-			files = fp.read().splitlines()
-		with open('${write_lines(ref_files)}','r') as fp:
-			ref_files = fp.read().splitlines()
+        result = OrderedDict()
+        match = OrderedDict()
+        match_overall = True
 
-		result = OrderedDict()
-		match = OrderedDict()
-		match_overall = True
+        result['tasks'] = []
+        result['failed_task_labels'] = []
+        result['succeeded_task_labels'] = []
+        for i, label in enumerate(labels):
+            f = files[i]
+            ref_f = ref_files[i]
+            md5 = md5sum(f)
+            ref_md5 = md5sum(ref_f)
+            # if text file, read in contents
+            if f.endswith('.qc') or f.endswith('.txt') or \
+                f.endswith('.log') or f.endswith('.out'):
+                with open(f,'r') as fp:
+                    contents = fp.read()
+                with open(ref_f,'r') as fp:
+                    ref_contents = fp.read()
+            else:
+                contents = ''
+                ref_contents = ''
+            matched = md5==ref_md5
+            result['tasks'].append(OrderedDict([
+                ('label', label),
+                ('match', matched),
+                ('md5sum', md5),
+                ('ref_md5sum', ref_md5),
+                ('basename', os.path.basename(f)),
+                ('ref_basename', os.path.basename(ref_f)),
+                ('contents', contents),
+                ('ref_contents', ref_contents),
+                ]))
+            match[label] = matched
+            match_overall &= matched
+            if matched:
+                result['succeeded_task_labels'].append(label)
+            else:
+                result['failed_task_labels'].append(label)        
+        result['match_overall'] = match_overall
 
-		result['tasks'] = []
-		result['failed_task_labels'] = []
-		result['succeeded_task_labels'] = []
-		for i, label in enumerate(labels):
-			f = files[i]
-			ref_f = ref_files[i]
-			md5 = md5sum(f)
-			ref_md5 = md5sum(ref_f)
-			# if text file, read in contents
-			if f.endswith('.qc') or f.endswith('.txt') or \
-				f.endswith('.log') or f.endswith('.out'):
-				with open(f,'r') as fp:
-					contents = fp.read()
-				with open(ref_f,'r') as fp:
-					ref_contents = fp.read()
-			else:
-				contents = ''
-				ref_contents = ''
-			matched = md5==ref_md5
-			result['tasks'].append(OrderedDict([
-				('label', label),
-				('match', matched),
-				('md5sum', md5),
-				('ref_md5sum', ref_md5),
-				('basename', os.path.basename(f)),
-				('ref_basename', os.path.basename(ref_f)),
-				('contents', contents),
-				('ref_contents', ref_contents),
-				]))
-			match[label] = matched
-			match_overall &= matched
-			if matched:
-				result['succeeded_task_labels'].append(label)
-			else:
-				result['failed_task_labels'].append(label)		
-		result['match_overall'] = match_overall
-
-		with open('result.json','w') as fp:
-			fp.write(json.dumps(result, indent=4))
-		match_tmp = []
-		for key in match:
-			val = match[key]
-			match_tmp.append('{}\t{}'.format(key, val))
-		with open('match.tsv','w') as fp:
-			fp.writelines('\n'.join(match_tmp))
-		with open('match_overall.txt','w') as fp:
-			fp.write(str(match_overall))
-		CODE
-	>>>
-	output {
-		Map[String,String] match = read_map('match.tsv') # key:label, val:match
-		Boolean match_overall = read_boolean('match_overall.txt')
-		File json = glob('result.json')[0] # details (json file)
-		String json_str = read_string('result.json') # details (string)
-	}
-	runtime {
-		cpu : 1
-		memory : '4000 MB'
-		time : 1
-		disks : 'local-disk 50 HDD'
-	}
+        with open('result.json','w') as fp:
+            fp.write(json.dumps(result, indent=4))
+        match_tmp = []
+        for key in match:
+            val = match[key]
+            match_tmp.append('{}\t{}'.format(key, val))
+        with open('match.tsv','w') as fp:
+            fp.writelines('\n'.join(match_tmp))
+        with open('match_overall.txt','w') as fp:
+            fp.write(str(match_overall))
+        CODE
+    >>>
+    output {
+        Map[String,String] match = read_map('match.tsv') # key:label, val:match
+        Boolean match_overall = read_boolean('match_overall.txt')
+        File json = glob('result.json')[0] # details (json file)
+        String json_str = read_string('result.json') # details (string)
+    }
+    runtime {
+        cpu : 1
+        memory : '4000 MB'
+        time : 1
+        disks : 'local-disk 50 HDD'
+    }
 }

--- a/dev/test/test_task/test_annot_enrich.json
+++ b/dev/test/test_task/test_annot_enrich.json
@@ -1,5 +1,4 @@
 {
-    "test_annot_enrich.paired_end" : true,
     "test_annot_enrich.blacklist" : "atac-seq-pipeline-test-data/genome_data/hg38_chr19_chrM/hg38.blacklist.bed.gz",
     "test_annot_enrich.dnase" : "atac-seq-pipeline-test-data/genome_data/hg38/ataqc/reg2map_honeybadger2_dnase_all_p10_ucsc.hg19_to_hg38.bed.gz",
     "test_annot_enrich.prom" : "atac-seq-pipeline-test-data/genome_data/hg38/ataqc/reg2map_honeybadger2_dnase_prom_p2.hg19_to_hg38.bed.gz",

--- a/dev/test/test_task/test_annot_enrich.wdl
+++ b/dev/test/test_task/test_annot_enrich.wdl
@@ -1,34 +1,34 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_annot_enrich {
-	File ta
-	File blacklist
-	File dnase
-	File prom
-	File enh
+    input {
+        File ta
+        File blacklist
+        File dnase
+        File prom
+        File enh
+        File ref_annot_enrich_qc
+    }
 
-	File ref_annot_enrich_qc
+    call atac.annot_enrich { input : 
+        ta = ta,
+        blacklist = blacklist,
+        dnase = dnase,
+        prom = prom,
+        enh = enh,
+    }
 
-	call atac.annot_enrich { input : 
-		ta = ta,
-		blacklist = blacklist,
-		dnase = dnase,
-		prom = prom,
-		enh = enh,
-	}
-
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'test_annot_enrich_qc',
-		],
-		files = [
-			annot_enrich.annot_enrich_qc,
-		],
-		ref_files = [
-			ref_annot_enrich_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'test_annot_enrich_qc',
+        ],
+        files = [
+            annot_enrich.annot_enrich_qc,
+        ],
+        ref_files = [
+            ref_annot_enrich_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_bam2ta.wdl
+++ b/dev/test/test_task/test_bam2ta.wdl
@@ -1,124 +1,125 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_bam2ta {
-	Int bam2ta_subsample
+    input {
+        Int bam2ta_subsample
 
-	String pe_nodup_bam
-	String se_nodup_bam
+        String pe_nodup_bam
+        String se_nodup_bam
 
-	String ref_pe_ta
-	String ref_pe_ta_disable_tn5_shift
-	String ref_pe_ta_subsample
-	String ref_se_ta
-	String ref_se_ta_disable_tn5_shift
-	String ref_se_ta_subsample
-	String mito_chr_name = 'chrM'
+        String ref_pe_ta
+        String ref_pe_ta_disable_tn5_shift
+        String ref_pe_ta_subsample
+        String ref_se_ta
+        String ref_se_ta_disable_tn5_shift
+        String ref_se_ta_subsample
+        String mito_chr_name = 'chrM'
 
-	Int bam2ta_cpu = 1
-	Int bam2ta_mem_mb = 10000
-	Int bam2ta_time_hr = 6
-	String bam2ta_disks = 'local-disk 100 HDD'
+        Int bam2ta_cpu = 1
+        Int bam2ta_mem_mb = 10000
+        Int bam2ta_time_hr = 6
+        String bam2ta_disks = 'local-disk 100 HDD'
+    }
 
-	call atac.bam2ta as pe_bam2ta { input :
-		bam = pe_nodup_bam,
-		disable_tn5_shift = false,
-		subsample = 0,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
+    call atac.bam2ta as pe_bam2ta { input :
+        bam = pe_nodup_bam,
+        disable_tn5_shift = false,
+        subsample = 0,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
 
-		cpu = bam2ta_cpu,
-		mem_mb = bam2ta_mem_mb,
-		time_hr = bam2ta_time_hr,
-		disks = bam2ta_disks,
-	}
-	call atac.bam2ta as pe_bam2ta_disable_tn5_shift { input :
-		bam = pe_nodup_bam,
-		disable_tn5_shift = true,
-		subsample = 0,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
+        cpu = bam2ta_cpu,
+        mem_mb = bam2ta_mem_mb,
+        time_hr = bam2ta_time_hr,
+        disks = bam2ta_disks,
+    }
+    call atac.bam2ta as pe_bam2ta_disable_tn5_shift { input :
+        bam = pe_nodup_bam,
+        disable_tn5_shift = true,
+        subsample = 0,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
 
-		cpu = bam2ta_cpu,
-		mem_mb = bam2ta_mem_mb,
-		time_hr = bam2ta_time_hr,
-		disks = bam2ta_disks,
-	}
-	call atac.bam2ta as pe_bam2ta_subsample { input :
-		bam = pe_nodup_bam,
-		disable_tn5_shift = false,
-		subsample = bam2ta_subsample,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
+        cpu = bam2ta_cpu,
+        mem_mb = bam2ta_mem_mb,
+        time_hr = bam2ta_time_hr,
+        disks = bam2ta_disks,
+    }
+    call atac.bam2ta as pe_bam2ta_subsample { input :
+        bam = pe_nodup_bam,
+        disable_tn5_shift = false,
+        subsample = bam2ta_subsample,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
 
-		cpu = bam2ta_cpu,
-		mem_mb = bam2ta_mem_mb,
-		time_hr = bam2ta_time_hr,
-		disks = bam2ta_disks,
-	}
-	call atac.bam2ta as se_bam2ta { input :
-		bam = se_nodup_bam,
-		disable_tn5_shift = false,
-		subsample = 0,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
+        cpu = bam2ta_cpu,
+        mem_mb = bam2ta_mem_mb,
+        time_hr = bam2ta_time_hr,
+        disks = bam2ta_disks,
+    }
+    call atac.bam2ta as se_bam2ta { input :
+        bam = se_nodup_bam,
+        disable_tn5_shift = false,
+        subsample = 0,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
 
-		cpu = bam2ta_cpu,
-		mem_mb = bam2ta_mem_mb,
-		time_hr = bam2ta_time_hr,
-		disks = bam2ta_disks,
-	}
-	call atac.bam2ta as se_bam2ta_disable_tn5_shift { input :
-		bam = se_nodup_bam,
-		disable_tn5_shift = true,
-		subsample = 0,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
+        cpu = bam2ta_cpu,
+        mem_mb = bam2ta_mem_mb,
+        time_hr = bam2ta_time_hr,
+        disks = bam2ta_disks,
+    }
+    call atac.bam2ta as se_bam2ta_disable_tn5_shift { input :
+        bam = se_nodup_bam,
+        disable_tn5_shift = true,
+        subsample = 0,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
 
-		cpu = bam2ta_cpu,
-		mem_mb = bam2ta_mem_mb,
-		time_hr = bam2ta_time_hr,
-		disks = bam2ta_disks,
-	}
-	call atac.bam2ta as se_bam2ta_subsample { input :
-		bam = se_nodup_bam,
-		disable_tn5_shift = false,
-		subsample = bam2ta_subsample,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
+        cpu = bam2ta_cpu,
+        mem_mb = bam2ta_mem_mb,
+        time_hr = bam2ta_time_hr,
+        disks = bam2ta_disks,
+    }
+    call atac.bam2ta as se_bam2ta_subsample { input :
+        bam = se_nodup_bam,
+        disable_tn5_shift = false,
+        subsample = bam2ta_subsample,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
 
-		cpu = bam2ta_cpu,
-		mem_mb = bam2ta_mem_mb,
-		time_hr = bam2ta_time_hr,
-		disks = bam2ta_disks,
-	}
+        cpu = bam2ta_cpu,
+        mem_mb = bam2ta_mem_mb,
+        time_hr = bam2ta_time_hr,
+        disks = bam2ta_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_bam2ta',
-			'pe_bam2ta_disable_tn5_shift',
-			'pe_bam2ta_subsample',
-			'se_bam2ta',
-			'se_bam2ta_disable_tn5_shift',
-			'se_bam2ta_subsample',
-		],
-		files = [
-			pe_bam2ta.ta,
-			pe_bam2ta_disable_tn5_shift.ta,
-			pe_bam2ta_subsample.ta,
-			se_bam2ta.ta,
-			se_bam2ta_disable_tn5_shift.ta,
-			se_bam2ta_subsample.ta,
-		],
-		ref_files = [
-			ref_pe_ta,
-			ref_pe_ta_disable_tn5_shift,
-			ref_pe_ta_subsample,
-			ref_se_ta,
-			ref_se_ta_disable_tn5_shift,
-			ref_se_ta_subsample,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_bam2ta',
+            'pe_bam2ta_disable_tn5_shift',
+            'pe_bam2ta_subsample',
+            'se_bam2ta',
+            'se_bam2ta_disable_tn5_shift',
+            'se_bam2ta_subsample',
+        ],
+        files = [
+            pe_bam2ta.ta,
+            pe_bam2ta_disable_tn5_shift.ta,
+            pe_bam2ta_subsample.ta,
+            se_bam2ta.ta,
+            se_bam2ta_disable_tn5_shift.ta,
+            se_bam2ta_subsample.ta,
+        ],
+        ref_files = [
+            ref_pe_ta,
+            ref_pe_ta_disable_tn5_shift,
+            ref_pe_ta_subsample,
+            ref_se_ta,
+            ref_se_ta_disable_tn5_shift,
+            ref_se_ta_subsample,
+        ],
+    }
 }

--- a/dev/test/test_task/test_bowtie2.wdl
+++ b/dev/test/test_task/test_bowtie2.wdl
@@ -1,130 +1,131 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester for task bowtie2
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_bowtie2 {
-	Int multimapping
+    input {
+        Int multimapping
 
-	Array[String] pe_fastqs_R1
-	Array[String] pe_fastqs_R2
-	Array[String] se_fastqs_R1
+        Array[String] pe_fastqs_R1
+        Array[String] pe_fastqs_R2
+        Array[String] se_fastqs_R1
 
-	String se_chrsz
-	String pe_chrsz
-	String cutadapt_param = '-e 0.1 -m 5'
+        String se_chrsz
+        String pe_chrsz
+        String cutadapt_param = '-e 0.1 -m 5'
 
-	# we don't compare BAM because BAM's header includes date
-	# hence md5sums don't match all the time
-	String ref_pe_flagstat
-	String ref_pe_flagstat_no_multimapping
+        # we don't compare BAM because BAM's header includes date
+        # hence md5sums don't match all the time
+        String ref_pe_flagstat
+        String ref_pe_flagstat_no_multimapping
 
-	String ref_se_flagstat
-	String ref_se_flagstat_no_multimapping
+        String ref_se_flagstat
+        String ref_se_flagstat_no_multimapping
 
-	String pe_bowtie2_idx_tar
-	String se_bowtie2_idx_tar
+        String pe_bowtie2_idx_tar
+        String se_bowtie2_idx_tar
 
-	Int bowtie2_cpu = 1
-	Int bowtie2_mem_mb = 20000
-	Int bowtie2_time_hr = 48
-	String bowtie2_disks = 'local-disk 100 HDD'
+        Int bowtie2_cpu = 1
+        Int bowtie2_mem_mb = 20000
+        Int bowtie2_time_hr = 48
+        String bowtie2_disks = 'local-disk 100 HDD'
+    }
 
-	call atac.align as pe_bowtie2 { input :
-		aligner = 'bowtie2',
-		idx_tar = pe_bowtie2_idx_tar,
-		mito_chr_name = 'chrM',
-		fastqs_R1 = pe_fastqs_R1,
-		fastqs_R2 = pe_fastqs_R2,
-		adapters_R1 = [],
-		adapters_R2 = [],
-		cutadapt_param = cutadapt_param,
-		multimapping = multimapping,
-		paired_end = true,
-		chrsz = pe_chrsz,
-		auto_detect_adapter = true,
+    call atac.align as pe_bowtie2 { input :
+        aligner = 'bowtie2',
+        idx_tar = pe_bowtie2_idx_tar,
+        mito_chr_name = 'chrM',
+        fastqs_R1 = pe_fastqs_R1,
+        fastqs_R2 = pe_fastqs_R2,
+        adapters_R1 = [],
+        adapters_R2 = [],
+        cutadapt_param = cutadapt_param,
+        multimapping = multimapping,
+        paired_end = true,
+        chrsz = pe_chrsz,
+        auto_detect_adapter = true,
 
-		cpu = bowtie2_cpu,
-		mem_mb = bowtie2_mem_mb,
-		time_hr = bowtie2_time_hr,
-		disks = bowtie2_disks,
-	}
-	call atac.align as pe_bowtie2_no_multimapping { input :
-		aligner = 'bowtie2',
-		idx_tar = pe_bowtie2_idx_tar,
-		mito_chr_name = 'chrM',
-		fastqs_R1 = pe_fastqs_R1,
-		fastqs_R2 = pe_fastqs_R2,
-		adapters_R1 = [],
-		adapters_R2 = [],
-		cutadapt_param = cutadapt_param,
-		multimapping = 0,
-		paired_end = true,
-		chrsz = pe_chrsz,
-		auto_detect_adapter = true,
+        cpu = bowtie2_cpu,
+        mem_mb = bowtie2_mem_mb,
+        time_hr = bowtie2_time_hr,
+        disks = bowtie2_disks,
+    }
+    call atac.align as pe_bowtie2_no_multimapping { input :
+        aligner = 'bowtie2',
+        idx_tar = pe_bowtie2_idx_tar,
+        mito_chr_name = 'chrM',
+        fastqs_R1 = pe_fastqs_R1,
+        fastqs_R2 = pe_fastqs_R2,
+        adapters_R1 = [],
+        adapters_R2 = [],
+        cutadapt_param = cutadapt_param,
+        multimapping = 0,
+        paired_end = true,
+        chrsz = pe_chrsz,
+        auto_detect_adapter = true,
 
-		cpu = bowtie2_cpu,
-		mem_mb = bowtie2_mem_mb,
-		time_hr = bowtie2_time_hr,
-		disks = bowtie2_disks,
-	}
-	call atac.align as se_bowtie2 { input :
-		aligner = 'bowtie2',
-		idx_tar = se_bowtie2_idx_tar,
-		mito_chr_name = 'chrM',
-		fastqs_R1 = se_fastqs_R1,
-		fastqs_R2 = [],
-		adapters_R1 = [],
-		adapters_R2 = [],
-		cutadapt_param = cutadapt_param,
-		multimapping = multimapping,
-		paired_end = false,
-		chrsz = se_chrsz,
-		auto_detect_adapter = true,
+        cpu = bowtie2_cpu,
+        mem_mb = bowtie2_mem_mb,
+        time_hr = bowtie2_time_hr,
+        disks = bowtie2_disks,
+    }
+    call atac.align as se_bowtie2 { input :
+        aligner = 'bowtie2',
+        idx_tar = se_bowtie2_idx_tar,
+        mito_chr_name = 'chrM',
+        fastqs_R1 = se_fastqs_R1,
+        fastqs_R2 = [],
+        adapters_R1 = [],
+        adapters_R2 = [],
+        cutadapt_param = cutadapt_param,
+        multimapping = multimapping,
+        paired_end = false,
+        chrsz = se_chrsz,
+        auto_detect_adapter = true,
 
-		cpu = bowtie2_cpu,
-		mem_mb = bowtie2_mem_mb,
-		time_hr = bowtie2_time_hr,
-		disks = bowtie2_disks,
-	}
-	call atac.align as se_bowtie2_no_multimapping { input :
-		aligner = 'bowtie2',
-		idx_tar = se_bowtie2_idx_tar,
-		mito_chr_name = 'chrM',
-		fastqs_R1 = se_fastqs_R1,
-		fastqs_R2 = [],
-		adapters_R1 = [],
-		adapters_R2 = [],
-		cutadapt_param = cutadapt_param,
-		multimapping = 0,
-		paired_end = false,
-		chrsz = se_chrsz,
-		auto_detect_adapter = true,
+        cpu = bowtie2_cpu,
+        mem_mb = bowtie2_mem_mb,
+        time_hr = bowtie2_time_hr,
+        disks = bowtie2_disks,
+    }
+    call atac.align as se_bowtie2_no_multimapping { input :
+        aligner = 'bowtie2',
+        idx_tar = se_bowtie2_idx_tar,
+        mito_chr_name = 'chrM',
+        fastqs_R1 = se_fastqs_R1,
+        fastqs_R2 = [],
+        adapters_R1 = [],
+        adapters_R2 = [],
+        cutadapt_param = cutadapt_param,
+        multimapping = 0,
+        paired_end = false,
+        chrsz = se_chrsz,
+        auto_detect_adapter = true,
 
-		cpu = bowtie2_cpu,
-		mem_mb = bowtie2_mem_mb,
-		time_hr = bowtie2_time_hr,
-		disks = bowtie2_disks,
-	}
+        cpu = bowtie2_cpu,
+        mem_mb = bowtie2_mem_mb,
+        time_hr = bowtie2_time_hr,
+        disks = bowtie2_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_bowtie2',
-			'pe_bowtie2_no_multimapping',
-			'se_bowtie2',
-			'se_bowtie2_no_multimapping',
-		],
-		files = [
-			pe_bowtie2.samstat_qc,
-			pe_bowtie2_no_multimapping.samstat_qc,
-			se_bowtie2.samstat_qc,
-			se_bowtie2_no_multimapping.samstat_qc,
-		],
-		ref_files = [
-			ref_pe_flagstat,
-			ref_pe_flagstat_no_multimapping,
-			ref_se_flagstat,
-			ref_se_flagstat_no_multimapping,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_bowtie2',
+            'pe_bowtie2_no_multimapping',
+            'se_bowtie2',
+            'se_bowtie2_no_multimapping',
+        ],
+        files = [
+            pe_bowtie2.samstat_qc,
+            pe_bowtie2_no_multimapping.samstat_qc,
+            se_bowtie2.samstat_qc,
+            se_bowtie2_no_multimapping.samstat_qc,
+        ],
+        ref_files = [
+            ref_pe_flagstat,
+            ref_pe_flagstat_no_multimapping,
+            ref_se_flagstat,
+            ref_se_flagstat_no_multimapping,
+        ],
+    }
 }

--- a/dev/test/test_task/test_compare_signal_to_roadmap.wdl
+++ b/dev/test/test_task/test_compare_signal_to_roadmap.wdl
@@ -1,33 +1,34 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_compare_signal_to_roadmap {
-	File pval_bw
-	File reg2map_bed
-	File reg2map
-	File roadmap_meta
+    input {
+        File pval_bw
+        File reg2map_bed
+        File reg2map
+        File roadmap_meta
 
-	File ref_roadmap_compare_log
+        File ref_roadmap_compare_log
+    }
 
-	call atac.compare_signal_to_roadmap { input : 
-		pval_bw = pval_bw,
+    call atac.compare_signal_to_roadmap { input : 
+        pval_bw = pval_bw,
 
-		reg2map_bed = reg2map_bed,
-		reg2map = reg2map,
-		roadmap_meta = roadmap_meta,
-	}
+        reg2map_bed = reg2map_bed,
+        reg2map = reg2map,
+        roadmap_meta = roadmap_meta,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'ref_roadmap_compare_log',
-		],
-		files = [
-			compare_signal_to_roadmap.roadmap_compare_log,
-		],
-		ref_files = [
-			ref_roadmap_compare_log,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'ref_roadmap_compare_log',
+        ],
+        files = [
+            compare_signal_to_roadmap.roadmap_compare_log,
+        ],
+        ref_files = [
+            ref_roadmap_compare_log,
+        ],
+    }
 }

--- a/dev/test/test_task/test_count_signal_track.wdl
+++ b/dev/test/test_task/test_count_signal_track.wdl
@@ -1,33 +1,34 @@
-# ENCODE DCC atac-seq pipeline tester for task count_signal_track
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_count_signal_track {
-	String se_ta
+    input {    
+        String se_ta
 
-	String ref_se_count_signal_track_pos_bw
-	String ref_se_count_signal_track_neg_bw
+        String ref_se_count_signal_track_pos_bw
+        String ref_se_count_signal_track_neg_bw
 
-	String se_chrsz
+        String se_chrsz
+    }
 
-	call atac.count_signal_track as se_count_signal_track { input :
-		ta = se_ta,
-		chrsz = se_chrsz,
-	}
+    call atac.count_signal_track as se_count_signal_track { input :
+        ta = se_ta,
+        chrsz = se_chrsz,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_count_signal_track_pos_bw',
-			'se_count_signal_track_neg_bw',
-		],
-		files = [
-			se_count_signal_track.pos_bw,
-			se_count_signal_track.neg_bw,
-		],
-		ref_files = [
-			ref_se_count_signal_track_pos_bw,
-			ref_se_count_signal_track_neg_bw,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_count_signal_track_pos_bw',
+            'se_count_signal_track_neg_bw',
+        ],
+        files = [
+            se_count_signal_track.pos_bw,
+            se_count_signal_track.neg_bw,
+        ],
+        ref_files = [
+            ref_se_count_signal_track_pos_bw,
+            ref_se_count_signal_track_neg_bw,
+        ],
+    }
 }

--- a/dev/test/test_task/test_filter.wdl
+++ b/dev/test/test_task/test_filter.wdl
@@ -1,168 +1,169 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester for task filter
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_filter {
-	Int multimapping
+    input {
+        Int multimapping
 
-	String dup_marker = 'picard'
-	Int mapq_thresh = 30
+        String dup_marker = 'picard'
+        Int mapq_thresh = 30
 
-	String se_chrsz
-	String pe_chrsz
+        String se_chrsz
+        String pe_chrsz
 
-	String pe_bam
-	String pe_bam_no_multimapping
-	String se_bam
-	String se_bam_no_multimapping
+        String pe_bam
+        String pe_bam_no_multimapping
+        String se_bam
+        String se_bam_no_multimapping
 
-	String ref_pe_nodup_samstat_qc
-	String ref_pe_nodup_samstat_qc_no_multimapping
-	String ref_pe_filt_samstat_qc
-	String ref_se_nodup_samstat_qc
-	String ref_se_nodup_samstat_qc_no_multimapping
-	String ref_se_filt_samstat_qc
-	String mito_chr_name = 'chrM'
+        String ref_pe_nodup_samstat_qc
+        String ref_pe_nodup_samstat_qc_no_multimapping
+        String ref_pe_filt_samstat_qc
+        String ref_se_nodup_samstat_qc
+        String ref_se_nodup_samstat_qc_no_multimapping
+        String ref_se_filt_samstat_qc
+        String mito_chr_name = 'chrM'
 
-	Int filter_cpu = 1
-	Int filter_mem_mb = 20000
-	Int filter_time_hr = 24
-	String filter_disks = 'local-disk 100 HDD'
+        Int filter_cpu = 1
+        Int filter_mem_mb = 20000
+        Int filter_time_hr = 24
+        String filter_disks = 'local-disk 100 HDD'
+    }
 
-	call atac.filter as pe_filter { input :
-		bam = pe_bam,
-		multimapping = multimapping,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
-		chrsz = pe_chrsz,
-		filter_chrs = [mito_chr_name],
+    call atac.filter as pe_filter { input :
+        bam = pe_bam,
+        multimapping = multimapping,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
+        chrsz = pe_chrsz,
+        filter_chrs = [mito_chr_name],
 
-		dup_marker = dup_marker,
-		mapq_thresh = mapq_thresh,
-		no_dup_removal = false,
+        dup_marker = dup_marker,
+        mapq_thresh = mapq_thresh,
+        no_dup_removal = false,
 
-		cpu = filter_cpu,
-		mem_mb = filter_mem_mb,
-		picard_java_heap = '4G',
-		time_hr = filter_time_hr,
-		disks = filter_disks,
-	}
-	call atac.filter as pe_filter_no_multimapping { input :
-		bam = pe_bam_no_multimapping,
-		multimapping = 0,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
-		chrsz = pe_chrsz,
-		filter_chrs = [mito_chr_name],
+        cpu = filter_cpu,
+        mem_mb = filter_mem_mb,
+        picard_java_heap = '4G',
+        time_hr = filter_time_hr,
+        disks = filter_disks,
+    }
+    call atac.filter as pe_filter_no_multimapping { input :
+        bam = pe_bam_no_multimapping,
+        multimapping = 0,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
+        chrsz = pe_chrsz,
+        filter_chrs = [mito_chr_name],
 
-		dup_marker = dup_marker,
-		mapq_thresh = mapq_thresh,
-		no_dup_removal = false,
+        dup_marker = dup_marker,
+        mapq_thresh = mapq_thresh,
+        no_dup_removal = false,
 
-		cpu = filter_cpu,
-		mem_mb = filter_mem_mb,
-		picard_java_heap = '4G',
-		time_hr = filter_time_hr,
-		disks = filter_disks,
-	}
-	call atac.filter as pe_filter_no_dup_removal { input :
-		bam = pe_bam,
-		multimapping = multimapping,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
-		chrsz = pe_chrsz,
-		filter_chrs = [mito_chr_name],
+        cpu = filter_cpu,
+        mem_mb = filter_mem_mb,
+        picard_java_heap = '4G',
+        time_hr = filter_time_hr,
+        disks = filter_disks,
+    }
+    call atac.filter as pe_filter_no_dup_removal { input :
+        bam = pe_bam,
+        multimapping = multimapping,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
+        chrsz = pe_chrsz,
+        filter_chrs = [mito_chr_name],
 
-		dup_marker = dup_marker,
-		mapq_thresh = mapq_thresh,
-		no_dup_removal = true,
+        dup_marker = dup_marker,
+        mapq_thresh = mapq_thresh,
+        no_dup_removal = true,
 
-		cpu = filter_cpu,
-		mem_mb = filter_mem_mb,
-		picard_java_heap = '4G',
-		time_hr = filter_time_hr,
-		disks = filter_disks,
-	}
-	call atac.filter as se_filter { input :
-		bam = se_bam,
-		multimapping = multimapping,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
-		chrsz = se_chrsz,
-		filter_chrs = [mito_chr_name],
+        cpu = filter_cpu,
+        mem_mb = filter_mem_mb,
+        picard_java_heap = '4G',
+        time_hr = filter_time_hr,
+        disks = filter_disks,
+    }
+    call atac.filter as se_filter { input :
+        bam = se_bam,
+        multimapping = multimapping,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
+        chrsz = se_chrsz,
+        filter_chrs = [mito_chr_name],
 
-		dup_marker = dup_marker,
-		mapq_thresh = mapq_thresh,
-		no_dup_removal = false,
+        dup_marker = dup_marker,
+        mapq_thresh = mapq_thresh,
+        no_dup_removal = false,
 
-		cpu = filter_cpu,
-		mem_mb = filter_mem_mb,
-		picard_java_heap = '4G',
-		time_hr = filter_time_hr,
-		disks = filter_disks,
-	}
-	call atac.filter as se_filter_no_multimapping { input :
-		bam = se_bam_no_multimapping,
-		multimapping = 0,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
-		chrsz = se_chrsz,
-		filter_chrs = [mito_chr_name],
+        cpu = filter_cpu,
+        mem_mb = filter_mem_mb,
+        picard_java_heap = '4G',
+        time_hr = filter_time_hr,
+        disks = filter_disks,
+    }
+    call atac.filter as se_filter_no_multimapping { input :
+        bam = se_bam_no_multimapping,
+        multimapping = 0,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
+        chrsz = se_chrsz,
+        filter_chrs = [mito_chr_name],
 
-		dup_marker = dup_marker,
-		mapq_thresh = mapq_thresh,
-		no_dup_removal = false,
+        dup_marker = dup_marker,
+        mapq_thresh = mapq_thresh,
+        no_dup_removal = false,
 
-		cpu = filter_cpu,
-		mem_mb = filter_mem_mb,
-		picard_java_heap = '4G',
-		time_hr = filter_time_hr,
-		disks = filter_disks,
-	}
-	call atac.filter as se_filter_no_dup_removal { input :
-		bam = se_bam,
-		multimapping = multimapping,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
-		chrsz = se_chrsz,
-		filter_chrs = [mito_chr_name],
+        cpu = filter_cpu,
+        mem_mb = filter_mem_mb,
+        picard_java_heap = '4G',
+        time_hr = filter_time_hr,
+        disks = filter_disks,
+    }
+    call atac.filter as se_filter_no_dup_removal { input :
+        bam = se_bam,
+        multimapping = multimapping,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
+        chrsz = se_chrsz,
+        filter_chrs = [mito_chr_name],
 
-		dup_marker = dup_marker,
-		mapq_thresh = mapq_thresh,
-		no_dup_removal = true,
+        dup_marker = dup_marker,
+        mapq_thresh = mapq_thresh,
+        no_dup_removal = true,
 
-		cpu = filter_cpu,
-		mem_mb = filter_mem_mb,
-		picard_java_heap = '4G',
-		time_hr = filter_time_hr,
-		disks = filter_disks,
-	}
+        cpu = filter_cpu,
+        mem_mb = filter_mem_mb,
+        picard_java_heap = '4G',
+        time_hr = filter_time_hr,
+        disks = filter_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_filter',
-			'pe_filter_no_multimapping',
-			'pe_filter_no_dup_removal',
-			'se_filter',
-			'se_filter_no_multimapping',
-			'se_filter_no_dup_removal',
-		],
-		files = [
-			pe_filter.samstat_qc,
-			pe_filter_no_multimapping.samstat_qc,
-			pe_filter_no_dup_removal.samstat_qc,
-			se_filter.samstat_qc,
-			se_filter_no_multimapping.samstat_qc,
-			se_filter_no_dup_removal.samstat_qc,
-		],
-		ref_files = [
-			ref_pe_nodup_samstat_qc,
-			ref_pe_nodup_samstat_qc_no_multimapping,
-			ref_pe_filt_samstat_qc,
-			ref_se_nodup_samstat_qc,
-			ref_se_nodup_samstat_qc_no_multimapping,
-			ref_se_filt_samstat_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_filter',
+            'pe_filter_no_multimapping',
+            'pe_filter_no_dup_removal',
+            'se_filter',
+            'se_filter_no_multimapping',
+            'se_filter_no_dup_removal',
+        ],
+        files = [
+            pe_filter.samstat_qc,
+            pe_filter_no_multimapping.samstat_qc,
+            pe_filter_no_dup_removal.samstat_qc,
+            se_filter.samstat_qc,
+            se_filter_no_multimapping.samstat_qc,
+            se_filter_no_dup_removal.samstat_qc,
+        ],
+        ref_files = [
+            ref_pe_nodup_samstat_qc,
+            ref_pe_nodup_samstat_qc_no_multimapping,
+            ref_pe_filt_samstat_qc,
+            ref_se_nodup_samstat_qc,
+            ref_se_nodup_samstat_qc_no_multimapping,
+            ref_se_filt_samstat_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_frac_mito.wdl
+++ b/dev/test/test_task/test_frac_mito.wdl
@@ -1,28 +1,29 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester for task frac_mito
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_frac_mito {
-	File non_mito_samstat
-	File mito_samstat
+    input {
+        File non_mito_samstat
+        File mito_samstat
 
-	File ref_frac_mito_qc
+        File ref_frac_mito_qc
+    }
 
-	call atac.frac_mito as frac_mito { input:
-		non_mito_samstat = non_mito_samstat,
-		mito_samstat = mito_samstat,
-	}
+    call atac.frac_mito as frac_mito { input:
+        non_mito_samstat = non_mito_samstat,
+        mito_samstat = mito_samstat,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'frac_mito', 
-		],
-		files = [
-			frac_mito.frac_mito_qc,
-		],
-		ref_files = [
-			ref_frac_mito_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'frac_mito', 
+        ],
+        files = [
+            frac_mito.frac_mito_qc,
+        ],
+        ref_files = [
+            ref_frac_mito_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_fraglen_stat_pe.json
+++ b/dev/test/test_task/test_fraglen_stat_pe.json
@@ -1,6 +1,5 @@
 {
     "test_fraglen_stat_pe.nodup_bam" : "atac-seq-pipeline-test-data/input/pe/ataqc/ENCFF341MYG.subsampled.400.trim.merged.nodup.bam",
 
-    "test_fraglen_stat_pe.ref_nucleosomal_qc" : "atac-seq-pipeline-test-data/ref_output/test_fraglen_stat_pe/ENCFF341MYG.subsampled.400.trim.merged.nodup.nucleosomal.qc",
-    "test_fraglen_stat_pe.ref_fraglen_dist_plot" : "atac-seq-pipeline-test-data/ref_output/test_fraglen_stat_pe/ENCFF341MYG.subsampled.400.trim.merged.nodup.fraglen_dist.png"
+    "test_fraglen_stat_pe.ref_nucleosomal_qc" : "atac-seq-pipeline-test-data/ref_output/test_fraglen_stat_pe/ENCFF341MYG.subsampled.400.trim.merged.nodup.nucleosomal.qc"
 }

--- a/dev/test/test_task/test_fraglen_stat_pe.wdl
+++ b/dev/test/test_task/test_fraglen_stat_pe.wdl
@@ -1,27 +1,28 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_fraglen_stat_pe {
-	File nodup_bam
+    input {
+        File nodup_bam
 
-	File ref_nucleosomal_qc
+        File ref_nucleosomal_qc
+    }
 
-	call atac.fraglen_stat_pe { input : 
-		nodup_bam = nodup_bam,
-		picard_java_heap = '4G',
-	}
+    call atac.fraglen_stat_pe { input : 
+        nodup_bam = nodup_bam,
+        picard_java_heap = '4G',
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'test_nucleosomal_qc',
-		],
-		files = [
-			fraglen_stat_pe.nucleosomal_qc,
-		],
-		ref_files = [
-			ref_nucleosomal_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'test_nucleosomal_qc',
+        ],
+        files = [
+            fraglen_stat_pe.nucleosomal_qc,
+        ],
+        ref_files = [
+            ref_nucleosomal_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_gc_bias.json
+++ b/dev/test/test_task/test_gc_bias.json
@@ -1,8 +1,6 @@
 {
-    "test_gc_bias.paired_end" : true,
     "test_gc_bias.ref_fa" : "GRCh38_no_alt_analysis_set_GCA_000001405.15.fasta.gz",
     "test_gc_bias.nodup_bam" : "atac-seq-pipeline-test-data/input/pe/ataqc/ENCFF341MYG.subsampled.400.trim.merged.nodup.bam",
 
-    "test_gc_bias.ref_gc_plot" : "atac-seq-pipeline-test-data/ref_output/test_gc_bias/ENCFF341MYG.subsampled.400.trim.merged.nodup.gc.gc_plot.png",
     "test_gc_bias.ref_gc_log" : "atac-seq-pipeline-test-data/ref_output/test_gc_bias/ENCFF341MYG.subsampled.400.trim.merged.nodup.gc.txt"
 }

--- a/dev/test/test_task/test_gc_bias.wdl
+++ b/dev/test/test_task/test_gc_bias.wdl
@@ -1,49 +1,50 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_gc_bias {
-	File nodup_bam
+    input {
+        File nodup_bam
 
-	File ref_fa
+        File ref_fa
 
-	File ref_gc_log
+        File ref_gc_log
+    }
 
-	call atac.gc_bias { input : 
-		nodup_bam = nodup_bam,
-		ref_fa = ref_fa,
-		picard_java_heap = '4G',
-	}
+    call atac.gc_bias { input : 
+        nodup_bam = nodup_bam,
+        ref_fa = ref_fa,
+        picard_java_heap = '4G',
+    }
 
-	call remove_comments_from_gc_log { input :
-		gc_log = gc_bias.gc_log
-	}
+    call remove_comments_from_gc_log { input :
+        gc_log = gc_bias.gc_log
+    }
 
-	call remove_comments_from_gc_log as remove_comments_from_gc_log_ref { input :
-		gc_log = ref_gc_log
-	}
+    call remove_comments_from_gc_log as remove_comments_from_gc_log_ref { input :
+        gc_log = ref_gc_log
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'test_gc_log',
-		],
-		files = [
-			remove_comments_from_gc_log.filt_gc_log,
-		],
-		ref_files = [
-			remove_comments_from_gc_log_ref.filt_gc_log,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'test_gc_log',
+        ],
+        files = [
+            remove_comments_from_gc_log.filt_gc_log,
+        ],
+        ref_files = [
+            remove_comments_from_gc_log_ref.filt_gc_log,
+        ],
+    }
 }
 
 task remove_comments_from_gc_log {
-	File gc_log
-	command {
-		zcat -f ${gc_log} | grep -v '# ' \
-			> ${basename(gc_log) + '.date_filt_out'}
-	}
-	output {
-		File filt_gc_log = glob('*.date_filt_out')[0]
-	}
+    File gc_log
+    command {
+        zcat -f ${gc_log} | grep -v '# ' \
+            > ${basename(gc_log) + '.date_filt_out'}
+    }
+    output {
+        File filt_gc_log = glob('*.date_filt_out')[0]
+    }
 }

--- a/dev/test/test_task/test_gc_bias.wdl
+++ b/dev/test/test_task/test_gc_bias.wdl
@@ -39,7 +39,9 @@ workflow test_gc_bias {
 }
 
 task remove_comments_from_gc_log {
-    File gc_log
+    input {
+        File gc_log
+    }
     command {
         zcat -f ${gc_log} | grep -v '# ' \
             > ${basename(gc_log) + '.date_filt_out'}

--- a/dev/test/test_task/test_idr.wdl
+++ b/dev/test/test_task/test_idr.wdl
@@ -1,53 +1,54 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_idr {
-	Float idr_thresh
+    input {
+        Float idr_thresh
 
-	String se_peak_rep1
-	String se_peak_rep2
-	String se_peak_pooled
-	String se_ta_pooled
+        String se_peak_rep1
+        String se_peak_rep2
+        String se_peak_pooled
+        String se_ta_pooled
 
-	String ref_se_idr_peak
-	String ref_se_idr_bfilt_peak
-	String ref_se_idr_frip_qc
+        String ref_se_idr_peak
+        String ref_se_idr_bfilt_peak
+        String ref_se_idr_frip_qc
 
-	String se_blacklist
-	String se_chrsz
+        String se_blacklist
+        String se_chrsz
 
-	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+        String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+    }
 
-	call atac.idr as se_idr { input : 
-		prefix = 'rep1-rep2',
-		peak1 = se_peak_rep1,
-		peak2 = se_peak_rep2,
-		peak_pooled = se_peak_pooled,
-		idr_thresh = idr_thresh,
-		peak_type = 'narrowPeak',
-		rank = 'p.value',
-		blacklist = se_blacklist,
-		chrsz = se_chrsz,
-		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
-		ta = se_ta_pooled,
-	}
+    call atac.idr as se_idr { input : 
+        prefix = 'rep1-rep2',
+        peak1 = se_peak_rep1,
+        peak2 = se_peak_rep2,
+        peak_pooled = se_peak_pooled,
+        idr_thresh = idr_thresh,
+        peak_type = 'narrowPeak',
+        rank = 'p.value',
+        blacklist = se_blacklist,
+        chrsz = se_chrsz,
+        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+        ta = se_ta_pooled,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_idr_peak',
-			'se_idr_bfilt_peak',
-			'se_idr_frip_qc',
-		],
-		files = [se_idr.idr_peak,
-			se_idr.bfilt_idr_peak,
-			se_idr.frip_qc,
-		],
-		ref_files = [
-			ref_se_idr_peak,
-			ref_se_idr_bfilt_peak,
-			ref_se_idr_frip_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_idr_peak',
+            'se_idr_bfilt_peak',
+            'se_idr_frip_qc',
+        ],
+        files = [se_idr.idr_peak,
+            se_idr.bfilt_idr_peak,
+            se_idr.frip_qc,
+        ],
+        ref_files = [
+            ref_se_idr_peak,
+            ref_se_idr_bfilt_peak,
+            ref_se_idr_frip_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_jsd.wdl
+++ b/dev/test/test_task/test_jsd.wdl
@@ -1,79 +1,80 @@
-# ENCODE DCC atac-Seq pipeline tester for task jsd
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_jsd {
-	Array[File] se_nodup_bams
-	File se_blacklist
-	File se_fake_blacklist
-	Array[File] ref_se_jsd_logs
-	Array[File] ref_se_jsd_fake_blacklist_logs
-	# task level test data (BAM) is generated from BWA
-	# so we keep using 30 here, this should be 255 for bowtie2 BAMs
-	Int mapq_thresh = 30
+    input {
+        Array[File] se_nodup_bams
+        File se_blacklist
+        File se_fake_blacklist
+        Array[File] ref_se_jsd_logs
+        Array[File] ref_se_jsd_fake_blacklist_logs
+        # task level test data (BAM) is generated from BWA
+        # so we keep using 30 here, this should be 255 for bowtie2 BAMs
+        Int mapq_thresh = 30
 
-	Int jsd_cpu = 1
-	Int jsd_mem_mb = 12000
-	Int jsd_time_hr = 6
-	String jsd_disks = 'local-disk 100 HDD'
+        Int jsd_cpu = 1
+        Int jsd_mem_mb = 12000
+        Int jsd_time_hr = 6
+        String jsd_disks = 'local-disk 100 HDD'
+    }
 
-	call atac.jsd as se_jsd { input :
-		nodup_bams = se_nodup_bams,
-		blacklist = se_blacklist,
-		mapq_thresh = mapq_thresh,
+    call atac.jsd as se_jsd { input :
+        nodup_bams = se_nodup_bams,
+        blacklist = se_blacklist,
+        mapq_thresh = mapq_thresh,
 
-		cpu = jsd_cpu,
-		mem_mb = jsd_mem_mb,
-		time_hr = jsd_time_hr,
-		disks = jsd_disks,
-	}
+        cpu = jsd_cpu,
+        mem_mb = jsd_mem_mb,
+        time_hr = jsd_time_hr,
+        disks = jsd_disks,
+    }
 
-	call atac.jsd as se_jsd_fake_blacklist { input :
-		nodup_bams = se_nodup_bams,
-		blacklist = se_fake_blacklist,
-		mapq_thresh = mapq_thresh,
+    call atac.jsd as se_jsd_fake_blacklist { input :
+        nodup_bams = se_nodup_bams,
+        blacklist = se_fake_blacklist,
+        mapq_thresh = mapq_thresh,
 
-		cpu = jsd_cpu,
-		mem_mb = jsd_mem_mb,
-		time_hr = jsd_time_hr,
-		disks = jsd_disks,
-	}
+        cpu = jsd_cpu,
+        mem_mb = jsd_mem_mb,
+        time_hr = jsd_time_hr,
+        disks = jsd_disks,
+    }
 
-	# take first 8 columns (vaule in other columns are random)
-	#scatter(i in range(2)){
-	#	call take_8_cols { input :
-	#		f = se_jsd.jsd_qcs[i],
-	#	}
-	#	call take_8_cols as ref_take_8_cols { input :
-	#		f = ref_se_jsd_logs[i],
-	#	}
-	#}
+    # take first 8 columns (vaule in other columns are random)
+    #scatter(i in range(2)){
+    #    call take_8_cols { input :
+    #        f = se_jsd.jsd_qcs[i],
+    #    }
+    #    call take_8_cols as ref_take_8_cols { input :
+    #        f = ref_se_jsd_logs[i],
+    #    }
+    #}
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_jsd_rep1',
-			'se_jsd_fake_blacklist_rep1',
-		],
-		files = [
-			#take_8_cols.out[0],
-			se_jsd.jsd_qcs[0],
-			se_jsd_fake_blacklist.jsd_qcs[0],
-		],
-		ref_files = [
-			#ref_take_8_cols.out[0],
-			ref_se_jsd_logs[0],
-			ref_se_jsd_fake_blacklist_logs[0],
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_jsd_rep1',
+            'se_jsd_fake_blacklist_rep1',
+        ],
+        files = [
+            #take_8_cols.out[0],
+            se_jsd.jsd_qcs[0],
+            se_jsd_fake_blacklist.jsd_qcs[0],
+        ],
+        ref_files = [
+            #ref_take_8_cols.out[0],
+            ref_se_jsd_logs[0],
+            ref_se_jsd_fake_blacklist_logs[0],
+        ],
+    }
 }
 
 task take_8_cols {
-	File f
-	command {
-		cut -f 1-8 ${f} > out.txt
-	}
-	output {
-		File out = 'out.txt'
-	}
+    File f
+    command {
+        cut -f 1-8 ${f} > out.txt
+    }
+    output {
+        File out = 'out.txt'
+    }
 }

--- a/dev/test/test_task/test_jsd.wdl
+++ b/dev/test/test_task/test_jsd.wdl
@@ -70,7 +70,9 @@ workflow test_jsd {
 }
 
 task take_8_cols {
-    File f
+    input {
+        File f
+    }
     command {
         cut -f 1-8 ${f} > out.txt
     }

--- a/dev/test/test_task/test_macs2.wdl
+++ b/dev/test/test_task/test_macs2.wdl
@@ -1,63 +1,64 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester for task macs2
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_macs2 {
-	Int cap_num_peak
-	Float pval_thresh
-	Int smooth_win
+    input {
+        Int cap_num_peak
+        Float pval_thresh
+        Int smooth_win
 
-	# test macs2 for SE set only
-	String se_ta
+        # test macs2 for SE set only
+        String se_ta
 
-	String ref_se_macs2_npeak # raw narrow-peak
-	String ref_se_macs2_bfilt_npeak # blacklist filtered narrow-peak
-	String ref_se_macs2_frip_qc 
+        String ref_se_macs2_npeak # raw narrow-peak
+        String ref_se_macs2_bfilt_npeak # blacklist filtered narrow-peak
+        String ref_se_macs2_frip_qc 
 
-	String se_blacklist
-	String se_chrsz
-	String se_gensz
+        String se_blacklist
+        String se_chrsz
+        String se_gensz
 
-	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+        String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
 
-	Int macs2_mem_mb = 16000
-	Int macs2_time_hr = 24
-	String macs2_disks = 'local-disk 100 HDD'
+        Int macs2_mem_mb = 16000
+        Int macs2_time_hr = 24
+        String macs2_disks = 'local-disk 100 HDD'
+    }
 
-	call atac.call_peak as se_macs2 { input :
-		peak_caller = 'macs2',
-		peak_type = 'narrowPeak',
-		ta = se_ta,
-		gensz = se_gensz,
-		chrsz = se_chrsz,
-		cap_num_peak = cap_num_peak,
-		pval_thresh = pval_thresh,
-		smooth_win = smooth_win,
-		blacklist = se_blacklist,
-		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+    call atac.call_peak as se_macs2 { input :
+        peak_caller = 'macs2',
+        peak_type = 'narrowPeak',
+        ta = se_ta,
+        gensz = se_gensz,
+        chrsz = se_chrsz,
+        cap_num_peak = cap_num_peak,
+        pval_thresh = pval_thresh,
+        smooth_win = smooth_win,
+        blacklist = se_blacklist,
+        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
 
-		cpu = 1,
-		mem_mb = macs2_mem_mb,
-		time_hr = macs2_time_hr,
-		disks = macs2_disks,
-	}
+        cpu = 1,
+        mem_mb = macs2_mem_mb,
+        time_hr = macs2_time_hr,
+        disks = macs2_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_macs2_npeak',
-			'se_macs2_bfilt_npeak',
-			'se_macs2_frip_qc',
-		],
-		files = [
-			se_macs2.peak,
-			se_macs2.bfilt_peak,
-			se_macs2.frip_qc,
-		],
-		ref_files = [
-			ref_se_macs2_npeak,
-			ref_se_macs2_bfilt_npeak,
-			ref_se_macs2_frip_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_macs2_npeak',
+            'se_macs2_bfilt_npeak',
+            'se_macs2_frip_qc',
+        ],
+        files = [
+            se_macs2.peak,
+            se_macs2.bfilt_peak,
+            se_macs2.frip_qc,
+        ],
+        ref_files = [
+            ref_se_macs2_npeak,
+            ref_se_macs2_bfilt_npeak,
+            ref_se_macs2_frip_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_macs2_signal_track.wdl
+++ b/dev/test/test_task/test_macs2_signal_track.wdl
@@ -1,45 +1,46 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester for task macs2
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_macs2_signal_track {
-	Float pval_thresh
-	Int smooth_win
+    input {
+        Float pval_thresh
+        Int smooth_win
 
-	# test macs2 for SE set only
-	String se_ta
+        # test macs2 for SE set only
+        String se_ta
 
-	String ref_se_macs2_pval_bw # p-val signal
+        String ref_se_macs2_pval_bw # p-val signal
 
-	String se_chrsz
-	String se_gensz
+        String se_chrsz
+        String se_gensz
 
-	Int macs2_mem_mb = 16000
-	Int macs2_time_hr = 24
-	String macs2_disks = 'local-disk 100 HDD'
+        Int macs2_mem_mb = 16000
+        Int macs2_time_hr = 24
+        String macs2_disks = 'local-disk 100 HDD'
+    }
 
-	call atac.macs2_signal_track as se_macs2_signal_track { input :
-		ta = se_ta,
-		gensz = se_gensz,
-		chrsz = se_chrsz,
-		pval_thresh = pval_thresh,
-		smooth_win = smooth_win,
+    call atac.macs2_signal_track as se_macs2_signal_track { input :
+        ta = se_ta,
+        gensz = se_gensz,
+        chrsz = se_chrsz,
+        pval_thresh = pval_thresh,
+        smooth_win = smooth_win,
 
-		mem_mb = macs2_mem_mb,
-		time_hr = macs2_time_hr,
-		disks = macs2_disks,
-	}
+        mem_mb = macs2_mem_mb,
+        time_hr = macs2_time_hr,
+        disks = macs2_disks,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_macs2_pval_bw',
-		],
-		files = [
-			se_macs2_signal_track.pval_bw,
-		],
-		ref_files = [
-			ref_se_macs2_pval_bw,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_macs2_pval_bw',
+        ],
+        files = [
+            se_macs2_signal_track.pval_bw,
+        ],
+        ref_files = [
+            ref_se_macs2_pval_bw,
+        ],
+    }
 }

--- a/dev/test/test_task/test_overlap.wdl
+++ b/dev/test/test_task/test_overlap.wdl
@@ -1,50 +1,51 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_overlap {
-	String se_peak_rep1 # test overlap,idr for SE set only
-	String se_peak_rep2
-	String se_peak_pooled
-	String se_ta_pooled
+    input {
+        String se_peak_rep1 # test overlap,idr for SE set only
+        String se_peak_rep2
+        String se_peak_pooled
+        String se_ta_pooled
 
-	String ref_se_overlap_peak
-	String ref_se_overlap_bfilt_peak
-	String ref_se_overlap_frip_qc
+        String ref_se_overlap_peak
+        String ref_se_overlap_bfilt_peak
+        String ref_se_overlap_frip_qc
 
-	String se_blacklist
-	String se_chrsz
+        String se_blacklist
+        String se_chrsz
 
-	String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+        String regex_bfilt_peak_chr_name = 'chr[\\dXY]+'
+    }
 
-	call atac.overlap as se_overlap { input :
-		prefix = 'rep1-rep2',
-		peak1 = se_peak_rep1,
-		peak2 = se_peak_rep2,
-		peak_pooled = se_peak_pooled,
-		peak_type = 'narrowPeak',
-		blacklist = se_blacklist,
-		regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
-		chrsz = se_chrsz,
-		ta = se_ta_pooled,
-	}
+    call atac.overlap as se_overlap { input :
+        prefix = 'rep1-rep2',
+        peak1 = se_peak_rep1,
+        peak2 = se_peak_rep2,
+        peak_pooled = se_peak_pooled,
+        peak_type = 'narrowPeak',
+        blacklist = se_blacklist,
+        regex_bfilt_peak_chr_name = regex_bfilt_peak_chr_name,
+        chrsz = se_chrsz,
+        ta = se_ta_pooled,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_overlap_peak',
-			'se_overlap_bfilt_peak',
-			'se_overlap_frip_qc',
-		],
-		files = [
-			se_overlap.overlap_peak,
-			se_overlap.bfilt_overlap_peak,
-			se_overlap.frip_qc,
-		],
-		ref_files = [
-			ref_se_overlap_peak,
-			ref_se_overlap_bfilt_peak,
-			ref_se_overlap_frip_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_overlap_peak',
+            'se_overlap_bfilt_peak',
+            'se_overlap_frip_qc',
+        ],
+        files = [
+            se_overlap.overlap_peak,
+            se_overlap.bfilt_overlap_peak,
+            se_overlap.frip_qc,
+        ],
+        ref_files = [
+            ref_se_overlap_peak,
+            ref_se_overlap_bfilt_peak,
+            ref_se_overlap_frip_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_pool_ta.wdl
+++ b/dev/test/test_task/test_pool_ta.wdl
@@ -1,27 +1,28 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_pool_ta {
-	String se_ta_rep1
-	String se_ta_rep2
+    input {
+        String se_ta_rep1
+        String se_ta_rep2
 
-	String ref_se_pooled_ta
+        String ref_se_pooled_ta
+    }
 
-	call atac.pool_ta as se_pool_ta { input :
-		tas = [se_ta_rep1, se_ta_rep2],
-	}
+    call atac.pool_ta as se_pool_ta { input :
+        tas = [se_ta_rep1, se_ta_rep2],
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_pool_ta',
-		],
-		files = [
-			se_pool_ta.ta_pooled,
-		],
-		ref_files = [
-			ref_se_pooled_ta,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_pool_ta',
+        ],
+        files = [
+            se_pool_ta.ta_pooled,
+        ],
+        ref_files = [
+            ref_se_pooled_ta,
+        ],
+    }
 }

--- a/dev/test/test_task/test_preseq.wdl
+++ b/dev/test/test_task/test_preseq.wdl
@@ -1,35 +1,35 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_preseq {
-	File bam
-	Boolean paired_end
+    input {
+        File bam
+        Boolean paired_end
 
-	#File ref_qc_html
-	File ref_picard_est_lib_size_qc
-	File ref_preseq_log
+        File ref_picard_est_lib_size_qc
+        File ref_preseq_log
+    }
 
-	call atac.preseq { input : 
-		paired_end = paired_end,
-		bam = bam,
-		mem_mb = 4000,
-		picard_java_heap = '4G',
-	}
+    call atac.preseq { input : 
+        paired_end = paired_end,
+        bam = bam,
+        mem_mb = 4000,
+        picard_java_heap = '4G',
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'test_picard_est_lib_size_qc',
-			'test_preseq_log',
-		],
-		files = select_all([
-			preseq.picard_est_lib_size_qc,
-			preseq.preseq_log,
-		]),
-		ref_files = [
-			ref_picard_est_lib_size_qc,
-			ref_preseq_log,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'test_picard_est_lib_size_qc',
+            'test_preseq_log',
+        ],
+        files = select_all([
+            preseq.picard_est_lib_size_qc,
+            preseq.preseq_log,
+        ]),
+        ref_files = [
+            ref_picard_est_lib_size_qc,
+            ref_preseq_log,
+        ],
+    }
 }

--- a/dev/test/test_task/test_reproducibility.wdl
+++ b/dev/test/test_task/test_reproducibility.wdl
@@ -1,35 +1,36 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_reproducibility {
-	String se_overlap_peak_rep1_vs_rep2
-	String se_overlap_peak_rep1_pr
-	String se_overlap_peak_rep2_pr
-	String se_overlap_peak_ppr
-	String se_chrsz
+    input {
+        String se_overlap_peak_rep1_vs_rep2
+        String se_overlap_peak_rep1_pr
+        String se_overlap_peak_rep2_pr
+        String se_overlap_peak_ppr
+        String se_chrsz
 
-	String ref_se_reproducibility_qc
+        String ref_se_reproducibility_qc
+    }
 
-	call atac.reproducibility as se_reproducibility { input :
-		prefix = 'overlap',
-		peaks = [se_overlap_peak_rep1_vs_rep2],
-		peaks_pr = [se_overlap_peak_rep1_pr, se_overlap_peak_rep2_pr],
-		peak_ppr = se_overlap_peak_ppr,
-		peak_type = 'narrowPeak',
-		chrsz = se_chrsz,		
-	}
+    call atac.reproducibility as se_reproducibility { input :
+        prefix = 'overlap',
+        peaks = [se_overlap_peak_rep1_vs_rep2],
+        peaks_pr = [se_overlap_peak_rep1_pr, se_overlap_peak_rep2_pr],
+        peak_ppr = se_overlap_peak_ppr,
+        peak_type = 'narrowPeak',
+        chrsz = se_chrsz,        
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'se_reproducibility',
-		],
-		files = [
-			se_reproducibility.reproducibility_qc,
-		],
-		ref_files = [
-			ref_se_reproducibility_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'se_reproducibility',
+        ],
+        files = [
+            se_reproducibility.reproducibility_qc,
+        ],
+        ref_files = [
+            ref_se_reproducibility_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_spr.wdl
+++ b/dev/test/test_task/test_spr.wdl
@@ -1,50 +1,51 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_spr {
-	String pe_ta
-	String se_ta
+    input {
+        String pe_ta
+        String se_ta
 
-	String ref_pe_ta_pr1
-	String ref_pe_ta_pr2
-	String ref_se_ta_pr1
-	String ref_se_ta_pr2
+        String ref_pe_ta_pr1
+        String ref_pe_ta_pr2
+        String ref_se_ta_pr1
+        String ref_se_ta_pr2
+    }
 
-	Int spr_mem_mb = 16000
+    Int spr_mem_mb = 16000
 
-	call atac.spr as pe_spr { input :
-		ta = pe_ta,
-		paired_end = true,
+    call atac.spr as pe_spr { input :
+        ta = pe_ta,
+        paired_end = true,
 
-		mem_mb = spr_mem_mb,
-	}	
-	call atac.spr as se_spr { input :
-		ta = se_ta,
-		paired_end = false,
+        mem_mb = spr_mem_mb,
+    }    
+    call atac.spr as se_spr { input :
+        ta = se_ta,
+        paired_end = false,
 
-		mem_mb = spr_mem_mb,
-	}
+        mem_mb = spr_mem_mb,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_spr_pr1',
-			'pe_spr_pr2',
-			'se_spr_pr1',
-			'se_spr_pr2',
-		],
-		files = [
-			pe_spr.ta_pr1,
-			pe_spr.ta_pr2,
-			se_spr.ta_pr1,
-			se_spr.ta_pr2,
-		],
-		ref_files = [
-			ref_pe_ta_pr1,
-			ref_pe_ta_pr2,
-			ref_se_ta_pr1,
-			ref_se_ta_pr2,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_spr_pr1',
+            'pe_spr_pr2',
+            'se_spr_pr1',
+            'se_spr_pr2',
+        ],
+        files = [
+            pe_spr.ta_pr1,
+            pe_spr.ta_pr2,
+            se_spr.ta_pr1,
+            se_spr.ta_pr2,
+        ],
+        ref_files = [
+            ref_pe_ta_pr1,
+            ref_pe_ta_pr2,
+            ref_se_ta_pr1,
+            ref_se_ta_pr2,
+        ],
+    }
 }

--- a/dev/test/test_task/test_tss_enrich.wdl
+++ b/dev/test/test_task/test_tss_enrich.wdl
@@ -1,34 +1,35 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_tss_enrich {
-	File read_len_log
-	File nodup_bam
-	File tss
-	File chrsz
+    input {
+        File read_len_log
+        File nodup_bam
+        File tss
+        File chrsz
 
-	File ref_tss_enrich_qc
+        File ref_tss_enrich_qc
+    }
 
-	Int? read_len_ = read_int(read_len_log)
+    Int? read_len_ = read_int(read_len_log)
 
-	call atac.tss_enrich { input : 
-		read_len = read_len_,
-		nodup_bam = nodup_bam,
-		chrsz = chrsz,
-		tss = tss,
-	}
+    call atac.tss_enrich { input : 
+        read_len = read_len_,
+        nodup_bam = nodup_bam,
+        chrsz = chrsz,
+        tss = tss,
+    }
 
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'test_tss_enrich_qc',
-		],
-		files = [
-			tss_enrich.tss_enrich_qc,
-		],
-		ref_files = [
-			ref_tss_enrich_qc,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'test_tss_enrich_qc',
+        ],
+        files = [
+            tss_enrich.tss_enrich_qc,
+        ],
+        ref_files = [
+            ref_tss_enrich_qc,
+        ],
+    }
 }

--- a/dev/test/test_task/test_xcor.wdl
+++ b/dev/test/test_task/test_xcor.wdl
@@ -1,89 +1,89 @@
-# ENCODE DCC ATAC-Seq/DNase-Seq pipeline tester
-# Author: Jin Lee (leepc12@gmail.com)
+version 1.0
 import '../../../atac.wdl' as atac
 import 'compare_md5sum.wdl' as compare_md5sum
 
 workflow test_xcor {
-	Int xcor_subsample
-	Int xcor_subsample_default = 25000000
+    input {
+        Int xcor_subsample
+        Int xcor_subsample_default = 25000000
 
-	String pe_ta
-	String se_ta
+        String pe_ta
+        String se_ta
 
-	String ref_pe_xcor_log
-	String ref_pe_xcor_log_subsample
-	String ref_se_xcor_log
-	String ref_se_xcor_log_subsample
-	String mito_chr_name = 'chrM'
+        String ref_pe_xcor_log
+        String ref_pe_xcor_log_subsample
+        String ref_se_xcor_log
+        String ref_se_xcor_log_subsample
+        String mito_chr_name = 'chrM'
 
-	Int xcor_cpu = 1
-	Int xcor_mem_mb = 16000
-	Int xcor_time_hr = 6
-	String xcor_disks = 'local-disk 100 HDD'
+        Int xcor_cpu = 1
+        Int xcor_mem_mb = 16000
+        Int xcor_time_hr = 6
+        String xcor_disks = 'local-disk 100 HDD'
+    }
+    call atac.xcor as pe_xcor { input :
+        ta = pe_ta,
+        subsample = xcor_subsample_default,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
 
-	call atac.xcor as pe_xcor { input :
-		ta = pe_ta,
-		subsample = xcor_subsample_default,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
+        cpu = xcor_cpu,
+        mem_mb = xcor_mem_mb,
+        time_hr = xcor_time_hr,
+        disks = xcor_disks,
+    }
+    call atac.xcor as pe_xcor_subsample { input :
+        ta = pe_ta,
+        subsample = xcor_subsample,
+        paired_end = true,
+        mito_chr_name = mito_chr_name,
 
-		cpu = xcor_cpu,
-		mem_mb = xcor_mem_mb,
-		time_hr = xcor_time_hr,
-		disks = xcor_disks,
-	}
-	call atac.xcor as pe_xcor_subsample { input :
-		ta = pe_ta,
-		subsample = xcor_subsample,
-		paired_end = true,
-		mito_chr_name = mito_chr_name,
+        cpu = xcor_cpu,
+        mem_mb = xcor_mem_mb,
+        time_hr = xcor_time_hr,
+        disks = xcor_disks,
+    }
+    call atac.xcor as se_xcor { input :
+        ta = se_ta,
+        subsample = xcor_subsample_default,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
 
-		cpu = xcor_cpu,
-		mem_mb = xcor_mem_mb,
-		time_hr = xcor_time_hr,
-		disks = xcor_disks,
-	}
-	call atac.xcor as se_xcor { input :
-		ta = se_ta,
-		subsample = xcor_subsample_default,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
+        cpu = xcor_cpu,
+        mem_mb = xcor_mem_mb,
+        time_hr = xcor_time_hr,
+        disks = xcor_disks,
+    }
+    call atac.xcor as se_xcor_subsample { input :
+        ta = se_ta,
+        subsample = xcor_subsample,
+        paired_end = false,
+        mito_chr_name = mito_chr_name,
 
-		cpu = xcor_cpu,
-		mem_mb = xcor_mem_mb,
-		time_hr = xcor_time_hr,
-		disks = xcor_disks,
-	}
-	call atac.xcor as se_xcor_subsample { input :
-		ta = se_ta,
-		subsample = xcor_subsample,
-		paired_end = false,
-		mito_chr_name = mito_chr_name,
+        cpu = xcor_cpu,
+        mem_mb = xcor_mem_mb,
+        time_hr = xcor_time_hr,
+        disks = xcor_disks,
+    }
 
-		cpu = xcor_cpu,
-		mem_mb = xcor_mem_mb,
-		time_hr = xcor_time_hr,
-		disks = xcor_disks,
-	}
-
-	call compare_md5sum.compare_md5sum { input :
-		labels = [
-			'pe_xcor',
-			'pe_xcor_subsample',
-			'se_xcor',
-			'se_xcor_subsample',
-		],
-		files = [
-			pe_xcor.score,
-			pe_xcor_subsample.score,
-			se_xcor.score,
-			se_xcor_subsample.score,
-		],
-		ref_files = [
-			ref_pe_xcor_log,
-			ref_pe_xcor_log_subsample,
-			ref_se_xcor_log,
-			ref_se_xcor_log_subsample,
-		],
-	}
+    call compare_md5sum.compare_md5sum { input :
+        labels = [
+            'pe_xcor',
+            'pe_xcor_subsample',
+            'se_xcor',
+            'se_xcor_subsample',
+        ],
+        files = [
+            pe_xcor.score,
+            pe_xcor_subsample.score,
+            se_xcor.score,
+            se_xcor_subsample.score,
+        ],
+        ref_files = [
+            ref_pe_xcor_log,
+            ref_pe_xcor_log_subsample,
+            ref_se_xcor_log,
+            ref_se_xcor_log_subsample,
+        ],
+    }
 }

--- a/docs/input.md
+++ b/docs/input.md
@@ -33,8 +33,6 @@ Parameter|Type|Description
 `atac.ref_mito_fa`| File | Mito-only reference FASTA file
 `atac.bowtie2_idx_tar`| File | Bowtie2 index TAR file (uncompressed) built from FASTA file
 `atac.bowtie2_mito_idx_tar`| File | Mito-only Bowtie2 index TAR file (uncompressed) built from FASTA file
-`atac.custom_aligner_idx_tar` | File | Index TAR file (uncompressed) for your own aligner. See details about [how to use a custom aligner](#how-to-use-a-custom-aligner)
-`atac.custom_aligner_mito_idx_tar` | File | Mito-only index TAR file (uncompressed) for your own aligner. See details about [how to use a custom aligner](#how-to-use-a-custom-aligner)
 `atac.chrsz`| File | 2-col chromosome sizes file built from FASTA file with `faidx`
 `atac.blacklist`| File | BED file. Peaks overlapping these regions will be filtered out
 `atac.blacklist2`| File | Second blacklist. Two blacklist files (`atac.blacklist` and `atac.blacklist2`) will be merged.
@@ -148,7 +146,6 @@ Parameter|Default|Description
 Parameter|Type | Default|Description
 ---------|----|---|-----------
 `atac.multimapping` | Int | 4 | Multimapping reads
-`atac.custom_align_py` | File | | Python script for your custom aligner. See details about [how to use a custom aligner](#how-to-use-a-custom-aligner)
 
 ## Optional filtering parameters
 
@@ -174,7 +171,6 @@ Parameter|Default|Description
 `atac.smooth_win` | 150 | Size of smoothing window for MACS2 (macs2 callpeak --shift [-smooth_win/2] --extsize [smooth_win]).
 `atac.enable_idr` | true | Enable IDR (irreproducible discovery rate)
 `atac.idr_thresh` | 0.05 | Threshold for IDR
-`atac.custom_call_peak_py` | File | Python script for your custom peak caller. See details about [how to use a custom peak caller](#how-to-use-a-peak-caller)
 
 ## Optional pipeline flags
 
@@ -269,7 +265,7 @@ Parameter|Default
 
 > **IMPORTANT**: If you see memory Java errors, check the following resource parameters.
 
-There are special parameters to control maximum Java heap memory (e.g. `java -Xmx4G`) for Picard tools. They are strings including size units. Such string will be directly appended to Java's parameter `-Xmx`.
+There are special parameters to control maximum Java heap memory (e.g. `java -Xmx4G`) for Picard tools. They are strings including size units. Such string will be directly appended to Java's parameter `-Xmx`. If these parameters are not defined then pipeline uses 90% of each task's memory (e.g. `atac.filter_mem_mb`).
 
 Parameter|Default
 ---------|-------
@@ -277,145 +273,3 @@ Parameter|Default
 `atac.preseq_picard_java_heap` | = `atac.preseq_mem_mb`
 `atac.fraglen_stat_picard_java_heap` | `6G`
 `atac.gc_bias_picard_java_heap` | `10G`
-
-
-## How to use a custom aligner
-
-ENCODE ATAC-Seq pipeline currently supports `bowtie2` only. In order to use your own aligner you need to define the following parameters first. You can define `custom_aligner_idx_tar` either in your input JSON file or in your genome TSV file. Such index TAR file should be an uncompressed TAR file without any directory structured.
-
-Parameter|Type|Description
----------|-------|-----------
-`atac.custom_aligner_idx_tar` | File | Index TAR file (uncompressed) for your own aligner
-`atac.custom_align_py` | File | Python script for your custom aligner
-
-Here is a template for `custom_align.py`:
-
-```python
-#!/usr/bin/env python
-
-import os
-import argparse
-
-def parse_arguments():
-    parser = argparse.ArgumentParser(prog='ENCODE template aligner')
-    parser.add_argument('index_prefix_or_tar', type=str,
-                        help='Path for prefix (or a tarball .tar) \
-                            for reference aligner index. \
-                            Tar ball must be packed without compression \
-                            and directory by using command line \
-                            "tar cvf [TAR] [TAR_PREFIX].*')
-    parser.add_argument('fastqs', nargs='+', type=str,
-                        help='List of FASTQs (R1 and R2). \
-                            FASTQs must be compressed with gzip (with .gz).')
-    parser.add_argument('--paired-end', action="store_true",
-                        help='Paired-end FASTQs.')
-    parser.add_argument('--multimapping', default=4, type=int,
-                        help='Multimapping reads')
-    parser.add_argument('--nth', type=int, default=1,
-                        help='Number of threads to parallelize.')
-    parser.add_argument('--out-dir', default='', type=str,
-                            help='Output directory.')
-    args = parser.parse_args()
-
-    # check if fastqs have correct dimension
-    if args.paired_end and len(args.fastqs)!=2:
-        raise argparse.ArgumentTypeError('Need 2 fastqs for paired end.')
-    if not args.paired_end and len(args.fastqs)!=1:
-        raise argparse.ArgumentTypeError('Need 1 fastq for single end.')
-
-    return args
-
-def align(fastq_R1, fastq_R2, ref_index_prefix, multimapping, nth, out_dir):
-    basename = os.path.basename(os.path.splitext(fastq_R1)[0])    
-    prefix = os.path.join(out_dir, basename)
-    bam = '{}.bam'.format(prefix)
-
-    # map your fastqs somehow
-    os.system('touch {}'.format(bam))
-
-    return bam
-
-def main():
-    # read params
-    args = parse_arguments()
-   
-    # unpack index somehow on CWD
-    os.system('tar xvf {}'.format(args.index_prefix_or_tar))
-
-    bam = align(args.fastqs[0],
-                args.fastqs[1] if args.paired_end else None,
-                args.index_prefix_or_tar,
-                args.multimapping,
-                args.nth,
-                args.out_dir)
-
-if __name__=='__main__':
-    main()
-
-```
-
-> **IMPORTANT**: Your custom python script should generate ONLY one `*.bam` file. For example, if there are two `.bam` files then pipeline will just pick the first one in an alphatical order.
-
-## How to use a custom peak caller
-
-Parameter|Type|Default|Description
----------|-------|-----------
-`atac.peak_type` | String | `narrowPeak` | Only ENCODE peak types are supported: `narrowPeak`, `broadPeak` and `gappedPeak`
-`atac.custom_call_peak_py` | File | | Python script for your custom peak caller
-
-The file extension of your output peak file must be consitent with the `peak_type` you chose. For example, if you have chosen `narrowPeak` as `peak_type` then your output peak file should be `*.narrowPeak.gz`.
-
-Here is a template for `custom_call_peak.py`:
-
-```python
-#!/usr/bin/env python
-
-import os
-import argparse
-
-def parse_arguments():
-    parser = argparse.ArgumentParser(prog='ENCODE template call_peak')
-    parser.add_argument('ta', type=str,
-                        help='Path for TAGALIGN file')
-    parser.add_argument('--fraglen', type=int, required=True,
-                        help='Fragment length.')
-    parser.add_argument('--shift', type=int, default=0,
-                        help='macs2 callpeak --shift.')
-    parser.add_argument('--chrsz', type=str,
-                        help='2-col chromosome sizes file.')
-    parser.add_argument('--gensz', type=str,
-                        help='Genome size (sum of entries in 2nd column of \
-                            chr. sizes file, or hs for human, ms for mouse).')
-    parser.add_argument('--pval-thresh', default=0.01, type=float,
-                        help='P-Value threshold.')
-    parser.add_argument('--cap-num-peak', default=500000, type=int,
-                        help='Capping number of peaks by taking top N peaks.')
-    parser.add_argument('--out-dir', default='', type=str,
-                        help='Output directory.')
-    args = parser.parse_args()
-    return args
-
-def call_peak(ta, chrsz, gensz, pval_thresh, shift, fraglen, cap_num_peak, out_dir):
-    basename_ta = os.path.basename(os.path.splitext(ta)[0])
-    basename_prefix = basename_ta
-
-    prefix = os.path.join(out_dir, basename_prefix)
-    npeak = '{}.narrowPeak.gz'.format(prefix)
-
-    os.system('touch {}'.format(npeak))
-
-    return npeak
-
-def main():
-    # read params
-    args = parse_arguments()
-
-    npeak = call_peak(
-        args.ta, args.chrsz, args.gensz, args.pval_thresh,
-        args.shift, args.fraglen, args.cap_num_peak, args.out_dir)
-
-if __name__=='__main__':
-    main()
-```
-
-> **IMPORTANT**: Your custom python script should generate ONLY one `*.*Peak.gz` file. For example, if there are `*.narrowPeak.gz` and `*.broadPeak.gz` files pipeline will just pick the first one in an alphatical order.

--- a/docs/input_short.md
+++ b/docs/input_short.md
@@ -216,7 +216,7 @@ Parameter|Default
 
 > **IMPORTANT**: If you see memory Java errors, check the following resource parameters.
 
-There are special parameters to control maximum Java heap memory (e.g. `java -Xmx4G`) for Picard tools. They are strings including size units. Such string will be directly appended to Java's parameter `-Xmx`.
+There are special parameters to control maximum Java heap memory (e.g. `java -Xmx4G`) for Picard tools. They are strings including size units. Such string will be directly appended to Java's parameter `-Xmx`. If these parameters are not defined then pipeline uses 90% of each task's memory (e.g. `atac.filter_mem_mb`).
 
 Parameter|Default
 ---------|-------

--- a/example_input_json/dx/ENCSR356KRQ_subsampled_dx.json
+++ b/example_input_json/dx/ENCSR356KRQ_subsampled_dx.json
@@ -1,29 +1,29 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
+    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
     "atac.fastqs_rep1_R1" : [
-        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF341MYG.subsampled.400.fastq.gz",
-        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF106QGY.subsampled.400.fastq.gz"
+        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF341MYG.subsampled.400.fastq.gz",
+        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF106QGY.subsampled.400.fastq.gz"
     ],
     "atac.fastqs_rep1_R2" : [
-         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF248EJF.subsampled.400.fastq.gz",
-         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF368TYI.subsampled.400.fastq.gz"
+         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF248EJF.subsampled.400.fastq.gz",
+         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF368TYI.subsampled.400.fastq.gz"
     ],
     "atac.fastqs_rep2_R1" : [
-        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF641SFZ.subsampled.400.fastq.gz",
-        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF751XTV.subsampled.400.fastq.gz",
-        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF927LSG.subsampled.400.fastq.gz",
-        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF859BDM.subsampled.400.fastq.gz",
-        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF193RRC.subsampled.400.fastq.gz",
-        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF366DFI.subsampled.400.fastq.gz"
+        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF641SFZ.subsampled.400.fastq.gz",
+        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF751XTV.subsampled.400.fastq.gz",
+        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF927LSG.subsampled.400.fastq.gz",
+        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF859BDM.subsampled.400.fastq.gz",
+        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF193RRC.subsampled.400.fastq.gz",
+        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF366DFI.subsampled.400.fastq.gz"
     ],
     "atac.fastqs_rep2_R2" : [
-         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF031ARQ.subsampled.400.fastq.gz",
-         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF590SYZ.subsampled.400.fastq.gz",
-         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF734PEQ.subsampled.400.fastq.gz",
-         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF007USV.subsampled.400.fastq.gz",
-         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF886FSC.subsampled.400.fastq.gz",
-         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF573UXK.subsampled.400.fastq.gz"
+         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF031ARQ.subsampled.400.fastq.gz",
+         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF590SYZ.subsampled.400.fastq.gz",
+         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF734PEQ.subsampled.400.fastq.gz",
+         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF007USV.subsampled.400.fastq.gz",
+         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF886FSC.subsampled.400.fastq.gz",
+         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF573UXK.subsampled.400.fastq.gz"
     ],
     "atac.paired_end" : true,
     "atac.auto_detect_adapter" : true,

--- a/example_input_json/dx/ENCSR356KRQ_subsampled_rep1_dx.json
+++ b/example_input_json/dx/ENCSR356KRQ_subsampled_rep1_dx.json
@@ -1,13 +1,13 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
+    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv",
     "atac.fastqs_rep1_R1" : [
-        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF341MYG.subsampled.400.fastq.gz",
-        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF106QGY.subsampled.400.fastq.gz"
+        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF341MYG.subsampled.400.fastq.gz",
+        "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF106QGY.subsampled.400.fastq.gz"
     ],
     "atac.fastqs_rep1_R2" : [
-         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF248EJF.subsampled.400.fastq.gz",
-         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF368TYI.subsampled.400.fastq.gz"
+         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF248EJF.subsampled.400.fastq.gz",
+         "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF368TYI.subsampled.400.fastq.gz"
     ],
     "atac.paired_end" : true,
     "atac.auto_detect_adapter" : true,

--- a/example_input_json/dx/template_hg19.json
+++ b/example_input_json/dx/template_hg19.json
@@ -1,4 +1,4 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg19_dx.tsv"
+    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/hg19_dx.tsv"
 }

--- a/example_input_json/dx/template_hg38.json
+++ b/example_input_json/dx/template_hg38.json
@@ -1,4 +1,4 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv"
+    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/hg38_dx.tsv"
 }

--- a/example_input_json/dx/template_mm10.json
+++ b/example_input_json/dx/template_mm10.json
@@ -1,4 +1,4 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/mm10_dx.tsv"
+    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/mm10_dx.tsv"
 }

--- a/example_input_json/dx/template_mm9.json
+++ b/example_input_json/dx/template_mm9.json
@@ -1,4 +1,4 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:pipeline-genome-data/genome_tsv/v1/mm9_dx.tsv"
+    "atac.genome_tsv" : "dx://project-BKpvFg00VBPV975PgJ6Q03v6:/pipeline-genome-data/genome_tsv/v1/mm9_dx.tsv"
 }

--- a/example_input_json/dx_azure/ENCSR356KRQ_subsampled_dx_azure.json
+++ b/example_input_json/dx_azure/ENCSR356KRQ_subsampled_dx_azure.json
@@ -1,29 +1,29 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
+    "atac.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv",
     "atac.fastqs_rep1_R1" : [
-        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF341MYG.subsampled.400.fastq.gz",
-        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF106QGY.subsampled.400.fastq.gz"
+        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF341MYG.subsampled.400.fastq.gz",
+        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair1/ENCFF106QGY.subsampled.400.fastq.gz"
     ],
     "atac.fastqs_rep1_R2" : [
-         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF248EJF.subsampled.400.fastq.gz",
-         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF368TYI.subsampled.400.fastq.gz"
+         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF248EJF.subsampled.400.fastq.gz",
+         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep1/pair2/ENCFF368TYI.subsampled.400.fastq.gz"
     ],
     "atac.fastqs_rep2_R1" : [
-        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF641SFZ.subsampled.400.fastq.gz",
-        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF751XTV.subsampled.400.fastq.gz",
-        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF927LSG.subsampled.400.fastq.gz",
-        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF859BDM.subsampled.400.fastq.gz",
-        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF193RRC.subsampled.400.fastq.gz",
-        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF366DFI.subsampled.400.fastq.gz"
+        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF641SFZ.subsampled.400.fastq.gz",
+        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF751XTV.subsampled.400.fastq.gz",
+        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF927LSG.subsampled.400.fastq.gz",
+        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF859BDM.subsampled.400.fastq.gz",
+        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF193RRC.subsampled.400.fastq.gz",
+        "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF366DFI.subsampled.400.fastq.gz"
     ],
     "atac.fastqs_rep2_R2" : [
-         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF031ARQ.subsampled.400.fastq.gz",
-         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF590SYZ.subsampled.400.fastq.gz",
-         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF734PEQ.subsampled.400.fastq.gz",
-         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF007USV.subsampled.400.fastq.gz",
-         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF886FSC.subsampled.400.fastq.gz",
-         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF573UXK.subsampled.400.fastq.gz"
+         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF031ARQ.subsampled.400.fastq.gz",
+         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF590SYZ.subsampled.400.fastq.gz",
+         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF734PEQ.subsampled.400.fastq.gz",
+         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF007USV.subsampled.400.fastq.gz",
+         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF886FSC.subsampled.400.fastq.gz",
+         "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair2/ENCFF573UXK.subsampled.400.fastq.gz"
     ],
     "atac.paired_end" : true,
     "atac.auto_detect_adapter" : true,

--- a/example_input_json/dx_azure/template_hg19.json
+++ b/example_input_json/dx_azure/template_hg19.json
@@ -1,4 +1,4 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg19_dx_azure.tsv"
+    "atac.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/hg19_dx_azure.tsv"
 }

--- a/example_input_json/dx_azure/template_hg38.json
+++ b/example_input_json/dx_azure/template_hg38.json
@@ -1,4 +1,4 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv"
+    "atac.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/hg38_dx_azure.tsv"
 }

--- a/example_input_json/dx_azure/template_mm10.json
+++ b/example_input_json/dx_azure/template_mm10.json
@@ -1,4 +1,4 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/mm10_dx_azure.tsv"
+    "atac.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/mm10_dx_azure.tsv"
 }

--- a/example_input_json/dx_azure/template_mm9.json
+++ b/example_input_json/dx_azure/template_mm9.json
@@ -1,4 +1,4 @@
 {
     "atac.pipeline_type" : "atac",
-    "atac.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:pipeline-genome-data/genome_tsv/v1/mm9_dx_azure.tsv"
+    "atac.genome_tsv" : "dx://project-F6K911Q9xyfgJ36JFzv03Z5J:/pipeline-genome-data/genome_tsv/v1/mm9_dx_azure.tsv"
 }


### PR DESCRIPTION
Updated `atac.wdl` to WDL 1.0.
Updated DX workflow builder dXWDL to the latest (v1.46.4).
Made tasks fail on any error (`set -e`).

Linted `atac.wdl` to have whitepaces instead of TAB. So look at [this commit](https://github.com/ENCODE-DCC/atac-seq-pipeline/pull/253/commits/bff1d8352abd5bd5259c1af46a51bc6c384b5b40) for actual changes in `atac.wdl`. Changes are:
  - Mostly moved input variables into `input {}` section
  - Added `select_all()` for arrays to coerce `File?` to `File` since WDL 1.0 is strict about type coercion.
  - Made task file input variables optional (`File?`) due to the same coercion issue mentioned above.
  - Removed custom aligner/peak_caller options since they complicate the code structure too much.
  - Added `pipeline_meta {}` section. This section includes description and help context for each input variable.