### PR TITLE
PIP 1220 clip chrom end for peak files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,20 +48,20 @@ jobs:
             pyenv global 3.7.0
 
             cd dev/test/test_task/
-            #rm -rf atac-seq-pipeline-test-data
-            #export BOTO_CONFIG=/dev/null
-            #gsutil -m cp -r gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/atac-seq-pipeline-test-data .
-            #./download_hg38_fasta_for_test_ataqc.sh
-            #for wdl in test_*.wdl
-            #do
-            #  json=${wdl%.*}.json
-            #  result=${wdl%.*}.result.json
-            #  ./test.sh ${wdl} ${json} ${TAG}
-            #  if [[ $(wc -l "${result}" | awk '{print $1}') > 1 ]]; then
-            #    python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
-            #  fi
-            #  rm -f ${result}
-            #done
+            rm -rf atac-seq-pipeline-test-data
+            export BOTO_CONFIG=/dev/null
+            gsutil -m cp -r gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/atac-seq-pipeline-test-data .
+            ./download_hg38_fasta_for_test_ataqc.sh
+            for wdl in test_*.wdl
+            do
+              json=${wdl%.*}.json
+              result=${wdl%.*}.result.json
+              ./test.sh ${wdl} ${json} ${TAG}
+              if [[ $(wc -l "${result}" | awk '{print $1}') > 1 ]]; then
+                python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
+              fi
+              rm -f ${result}
+            done
             
   test_workflow_se:
     <<: *machine_defaults
@@ -133,15 +133,15 @@ workflows:
       - test_tasks:
           requires:
             - build
-#      - test_workflow_se:
-#          requires:
-#            - build
-#      - test_workflow_unrep_se:
-#          requires:
-#            - build
-#      - test_workflow_pe:
-#          requires:
-#            - build
-#      - test_workflow_pe_start_from_bam:
-#          requires:
-#            - build
+      - test_workflow_se:
+          requires:
+            - build
+      - test_workflow_unrep_se:
+          requires:
+            - build
+      - test_workflow_pe:
+          requires:
+            - build
+      - test_workflow_pe_start_from_bam:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,6 @@ jobs:
           no_output_timeout: 300m
           command: |
             source ${BASH_ENV}
-            # use python 3.7 for unittest
-            pyenv global 3.7.0
 
             cd dev/test/test_task/
             rm -rf atac-seq-pipeline-test-data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,39 +5,15 @@ defaults: &defaults
     - image: google/cloud-sdk:latest #circleci/buildpack-deps:xenial-scm
   working_directory: ~/atac-seq-pipeline
 
-python_defaults: &python_defaults
-  docker:
-    - image: quay.io/encode-dcc/atac-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}
-  working_directory: ~/atac-seq-pipeline
-
 machine_defaults: &machine_defaults
   machine: 
-    image: circleci/classic:latest
+    image: circleci/classic:201808-01
   working_directory: ~/atac-seq-pipeline
 
 make_tag: &make_tag
   name: make docker image tag
   command: |
-    echo "export TAG=quay.io/encode-dcc/atac-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" > ${BASH_ENV}
-    echo "export TAG_DOCKERHUB=encodedcc/atac-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" >> ${BASH_ENV}
-
-install_singularity: &install_singularity
-  name: install singularity
-  command: |
-    sudo apt-get update
-    sudo apt-get install \
-    python \
-    dh-autoreconf \
-    build-essential \
-    libarchive-dev \
-    squashfs-tools
-    wget https://github.com/singularityware/singularity/releases/download/2.6.0/singularity-2.6.0.tar.gz
-    tar xvf singularity-2.6.0.tar.gz
-    cd singularity-2.6.0
-    ./configure --prefix=/usr/local --sysconfdir=/etc
-    make
-    sudo make install
-    singularity --version
+    echo "export TAG=encodedcc/atac-seq-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}" >> ${BASH_ENV}
 
 # Define jobs here
 version: 2
@@ -52,13 +28,12 @@ jobs:
           name: build image
           command: |
             source ${BASH_ENV}
-            export DOCKER_CACHE_TAG=dev-v1.6.0
+            export DOCKER_CACHE_TAG=v1.7.1
             echo "pulling ${DOCKER_CACHE_TAG}!"
-            docker pull quay.io/encode-dcc/atac-seq-pipeline:${DOCKER_CACHE_TAG}
-            docker login -u=${QUAY_ROBOT_USER} -p=${QUAY_ROBOT_USER_TOKEN} quay.io
-            docker build --cache-from quay.io/encode-dcc/atac-seq-pipeline:${DOCKER_CACHE_TAG} --build-arg GIT_COMMIT_HASH=${CIRCLE_SHA1} --build-arg BRANCH=${CIRCLE_BRANCH} --build-arg BUILD_TAG=${TAG} -t $TAG -f dev/docker_image/Dockerfile .
+            docker pull encodedcc/atac-seq-pipeline:${DOCKER_CACHE_TAG}
+            docker login -u=${DOCKERHUB_USER} -p=${DOCKERHUB_PASS}
+            docker build --cache-from encodedcc/atac-seq-pipeline:${DOCKER_CACHE_TAG} --build-arg GIT_COMMIT_HASH=${CIRCLE_SHA1} --build-arg BRANCH=${CIRCLE_BRANCH} --build-arg BUILD_TAG=${TAG} -t $TAG -f dev/docker_image/Dockerfile .
             docker push ${TAG}
-            #docker push ${TAG_DOCKERHUB}
             docker logout
   test_tasks:
     <<: *machine_defaults
@@ -69,21 +44,24 @@ jobs:
           no_output_timeout: 300m
           command: |
             source ${BASH_ENV}
+            # use python 3.7 for unittest
+            pyenv global 3.7.0
+
             cd dev/test/test_task/
-            rm -rf atac-seq-pipeline-test-data
-            export BOTO_CONFIG=/dev/null
-            gsutil -m cp -r gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/atac-seq-pipeline-test-data .
-            ./download_hg38_fasta_for_test_ataqc.sh
-            for wdl in test_*.wdl
-            do
-              json=${wdl%.*}.json
-              result=${wdl%.*}.result.json
-              ./test.sh ${wdl} ${json} ${TAG}
-              if [[ $(wc -l "${result}" | awk '{print $1}') > 1 ]]; then
-                python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
-              fi
-              rm -f ${result}
-            done
+            #rm -rf atac-seq-pipeline-test-data
+            #export BOTO_CONFIG=/dev/null
+            #gsutil -m cp -r gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/atac-seq-pipeline-test-data .
+            #./download_hg38_fasta_for_test_ataqc.sh
+            #for wdl in test_*.wdl
+            #do
+            #  json=${wdl%.*}.json
+            #  result=${wdl%.*}.result.json
+            #  ./test.sh ${wdl} ${json} ${TAG}
+            #  if [[ $(wc -l "${result}" | awk '{print $1}') > 1 ]]; then
+            #    python -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data[u'match_overall']))" < ${result}
+            #  fi
+            #  rm -f ${result}
+            #done
             
   test_workflow_se:
     <<: *machine_defaults
@@ -155,15 +133,15 @@ workflows:
       - test_tasks:
           requires:
             - build
-      - test_workflow_se:
-          requires:
-            - build
-      - test_workflow_unrep_se:
-          requires:
-            - build
-      - test_workflow_pe:
-          requires:
-            - build
-      - test_workflow_pe_start_from_bam:
-          requires:
-            - build
+#      - test_workflow_se:
+#          requires:
+#            - build
+#      - test_workflow_unrep_se:
+#          requires:
+#            - build
+#      - test_workflow_pe:
+#          requires:
+#            - build
+#      - test_workflow_pe_start_from_bam:
+#          requires:
+#            - build

--- a/atac.wdl
+++ b/atac.wdl
@@ -8,8 +8,8 @@ workflow atac {
         description: 'ATAC-Seq/DNase-Seq pipeline'
         specification_document: 'https://docs.google.com/document/d/1f0Cm4vRyDQDu0bMehHD7P7KOMxTOP-HiNoIvL1VcBt8/edit?usp=sharing'
 
-        caper_docker: 'quay.io/encode-dcc/atac-seq-pipeline:dev-v1.7.2'
-        caper_singularity: 'docker://quay.io/encode-dcc/atac-seq-pipeline:dev-v1.7.2'
+        caper_docker: 'encodedcc/atac-seq-pipeline:dev-v1.7.2'
+        caper_singularity: 'docker://encodedcc/atac-seq-pipeline:dev-v1.7.2'
         croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/atac.croo.v4.json'
 
         parameter_group: {

--- a/dev/docker_image/Dockerfile
+++ b/dev/docker_image/Dockerfile
@@ -108,6 +108,9 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/software/kentUtils_bin_v377/lib
 # Instal Trimmomatic JAR
 RUN wget http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.39.zip && unzip Trimmomatic-0.39.zip && mv Trimmomatic-0.39/trimmomatic-0.39.jar trimmomatic.jar && chmod +rx trimmomatic.jar && rm -rf Trimmomatic-0.39.zip Trimmomatic-0.39/
 
+# Install pytest for testing environment
+RUN pip3 install --no-cache-dir pytest
+
 # Prevent conflict with locally installed python outside of singularity container
 ENV PYTHONNOUSERSITE=True
 
@@ -121,6 +124,8 @@ RUN mkdir -p /mnt/ext_{0..9}
 # make pipeline src directory to store py's
 RUN mkdir -p atac-seq-pipeline/src
 ENV PATH="/software/atac-seq-pipeline:/software/atac-seq-pipeline/src:${PATH}"
+RUN mkdir -p atac-seq-pipeline/dev/test/test_py
+ENV PYTHONPATH="/software/atac-seq-pipeline/src"
 
 # Get ENCODE atac-seq-pipeline container repository
 # This COPY assumes the build context is the root of the atac-seq-pipeline repo
@@ -129,4 +134,5 @@ ENV PATH="/software/atac-seq-pipeline:/software/atac-seq-pipeline/src:${PATH}"
 # cd [GIT_REPO_DIR] && docker build -f dev/docker_image/Dockerfile .
 COPY src atac-seq-pipeline/src/
 COPY atac.wdl atac-seq-pipeline/
+COPY dev/test/test_py atac-seq-pipeline/dev/test/test_py/
 

--- a/src/encode_lib_genomic.py
+++ b/src/encode_lib_genomic.py
@@ -599,3 +599,30 @@ def determine_paired(bam):
         return True
     else:
         return False
+
+
+def bed_clip(bed, chrsz, out_clipped_bed, no_gz=False):
+    '''
+    Make sure that bedClip (in USCS tools) is installed.
+    Clip a BED file between 0 and chromSize (taken from 2-col chrsz file).
+    bedClip exits with 255 if both start/end coordinates are
+    out of valid range (0-chromSize). Otherwise, reads/peaks will be truncated.
+
+    Args:
+        no_gz:
+            Do not gzip output.
+    '''
+    tmp_out = out_clipped_bed +  '.clip_tmp'
+    cmd = 'bedClip {bed} {chrsz} {tmp_out} -truncate -verbose=2'.format(
+        bed=bed,
+        chrsz=chrsz,
+        tmp_out=out_clipped_bed if no_gz else tmp_out)
+    run_shell_cmd(cmd)
+
+    if not no_gz:
+        cmd2 = 'cat {tmp_out} | gzip -nc > {out_clipped_bed}'.format(
+            tmp_out=tmp_out,
+            out_clipped_bed=out_clipped_bed)
+        run_shell_cmd(cmd2)
+
+        rm_f(tmp_out)

--- a/src/encode_task_macs2_atac.py
+++ b/src/encode_task_macs2_atac.py
@@ -9,6 +9,7 @@ import argparse
 from encode_lib_common import (
     assert_file_not_empty, human_readable_number,
     log, ls_l, mkdir_p, rm_f, run_shell_cmd, strip_ext_ta)
+from encode_lib_genomic import bed_clip
 
 
 def parse_arguments():
@@ -51,6 +52,7 @@ def macs2(ta, chrsz, gensz, pval_thresh, smooth_win, cap_num_peak,
         human_readable_number(cap_num_peak))
     # temporary files
     npeak_tmp = '{}.tmp'.format(npeak)
+    npeak_tmp2 = '{}.tmp2'.format(npeak)
 
     shiftsize = -int(round(float(smooth_win)/2.0))
     temp_files = []
@@ -78,12 +80,16 @@ def macs2(ta, chrsz, gensz, pval_thresh, smooth_win, cap_num_peak,
         npeak_tmp)
     run_shell_cmd(cmd1)
 
-    cmd2 = 'head -n {} {} | gzip -nc > {}'.format(
+    cmd2 = 'head -n {} {} > {}'.format(
         cap_num_peak,
         npeak_tmp,
-        npeak)
+        npeak_tmp2)
     run_shell_cmd(cmd2)
-    rm_f(npeak_tmp)
+
+    # clip peaks between 0-chromSize.
+    bed_clip(npeak_tmp2, chrsz, npeak)
+
+    rm_f([npeak_tmp, npeak_tmp2])
 
     # remove temporary files
     temp_files.append("{}_*".format(prefix))


### PR DESCRIPTION
See details here.
https://encodedcc.atlassian.net/browse/PIP-1220

Clip peak files' genome coordinate (start/end) with USCS tool bedClip.
What is clipped:
- Raw peak from MACS2
- IDR peak (12-col BED narrowPeak)
  - We don't need to clip overlap peak since it's simply based on bedtools intersect).
- IDR unthresholded peak (20-col BED)

`bed_clip` is added to `encode_lib_genomic.py` and called in multiple places (spp, macs2, idr).

Docker image repo migration is done: `quay.io` -> `dockerhub`.