### PR TITLE
PIP-1544 pseudoreplication random seed

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -219,6 +219,8 @@ Parameter|Type | Description
 Parameter|Default|Description
 ---------|-------|-----------
 `atac.filter_chrs` | `["chrM", "MT"]` | Array of chromosome names to be filtered out from a final (filtered/nodup) BAM. Mitochondrial chromosomes are filtered out by default.
+`atac.pseudoreplication_random_seed` | `0` | Random seed (positive integer) used for pseudo-replication (shuffling reads in TAG-ALIGN and then split it into two). If `0` then TAG-ALIGN file's size (in bytes) is used for random seed.
+
 
 > **WARNING**: If your custom genome's mitochondrial chromosome name is different from `chrM` or `MT`, then define it correctly here. This parameter has nothing to do with a mito-chromosome name parameter `atac.mito_chr_name`. Changing `atac.mito_chr_name` does not affect this parameter.
 

--- a/src/encode_task_spr.py
+++ b/src/encode_task_spr.py
@@ -18,6 +18,11 @@ def parse_arguments():
                         help='Path for TAGALIGN file.')
     parser.add_argument('--paired-end', action="store_true",
                         help='Paired-end TAGALIGN.')
+    parser.add_argument('--pseudoreplication-random-seed',
+                        type=int, default=0,
+                        help='Set it to 0 to use file\'s size (in bytes) as random seed.'
+                             'Otherwise this seed will be used for GNU shuf --random-source=sha256(seed).'
+                             'It is useful when random seed based on input file size does not work.')
     parser.add_argument('--out-dir', default='', type=str,
                         help='Output directory.')
     parser.add_argument('--log-level', default='INFO',
@@ -32,7 +37,7 @@ def parse_arguments():
     return args
 
 
-def spr_se(ta, out_dir):
+def spr_se(ta, pseudoreplication_random_seed, out_dir):
     prefix = os.path.join(out_dir,
                           os.path.basename(strip_ext_ta(ta)))
     tmp_pr1 = '{}.00'.format(prefix)
@@ -41,35 +46,38 @@ def spr_se(ta, out_dir):
     ta_pr2 = '{}.pr2.tagAlign.gz'.format(prefix)
     nlines = int((get_num_lines(ta)+1)/2)
 
+    if pseudoreplication_random_seed == 0:
+        random_seed = os.path.getsize(ta)
+        log.info(
+            'Using input file\'s size {seed} as random seed for pseudoreplication.'.format(seed=seed)
+        )
+    else:
+        random_seed = pseudoreplication_random_seed
+        log.info(
+            'Using a fixed integer {seed} as random seed for pseudoreplication.'.format(seed=seed)
+        )
+
     # bash-only
-    cmd1 = 'zcat {} | shuf --random-source=<(openssl enc '
-    cmd1 += '-aes-256-ctr -pass pass:$(zcat -f {} | wc -c) '
-    cmd1 += '-nosalt </dev/zero 2>/dev/null) | '
-    cmd1 += 'split -d -l {} - {}.'
-    cmd1 = cmd1.format(
-        ta,
-        ta,
-        nlines,
-        prefix)
-    run_shell_cmd(cmd1)
+    run_shell_cmd(
+        'zcat {ta} | shuf --random-source=<(openssl enc '
+        '-aes-256-ctr -pass pass:{random_seed} '
+        '-nosalt </dev/zero 2>/dev/null) | '
+        'split -d -l {nlines} - {prefix}.'.format(
+            ta=ta,
+            random_seed=random_seed,
+            nlines=nlines,
+            prefix=prefix,
+        )
+    )
 
-    cmd2 = 'gzip -nc {} > {}'
-    cmd2 = cmd2.format(
-        tmp_pr1,
-        ta_pr1)
-    run_shell_cmd(cmd2)
-
-    cmd3 = 'gzip -nc {} > {}'
-    cmd3 = cmd3.format(
-        tmp_pr2,
-        ta_pr2)
-    run_shell_cmd(cmd3)
+    run_shell_cmd('gzip -nc {tmp_pr1} > {ta_pr1}'.format(tmp_pr1=tmp_pr1, ta_pr1=ta_pr1))
+    run_shell_cmd('gzip -nc {tmp_pr2} > {ta_pr2}'.format(tmp_pr2=tmp_pr2, ta_pr2=ta_pr2))
 
     rm_f([tmp_pr1, tmp_pr2])
     return ta_pr1, ta_pr2
 
 
-def spr_pe(ta, out_dir):
+def spr_pe(ta, pseudoreplication_random_seed, out_dir):
     prefix = os.path.join(out_dir,
                           os.path.basename(strip_ext_ta(ta)))
     tmp_pr1 = '{}.00'.format(prefix)
@@ -78,40 +86,53 @@ def spr_pe(ta, out_dir):
     ta_pr2 = '{}.pr2.tagAlign.gz'.format(prefix)
     nlines = int((get_num_lines(ta)/2+1)/2)
 
+    if pseudoreplication_random_seed == 0:
+        random_seed = os.path.getsize(ta)
+        log.info(
+            'Using input file\'s size {seed} as random seed for pseudoreplication.'.format(seed=seed)
+        )
+    else:
+        random_seed = pseudoreplication_random_seed
+        log.info(
+            'Using a fixed integer {seed} as random seed for pseudoreplication.'.format(seed=seed)
+        )
+
     # bash-only
-    cmd1 = 'zcat -f {} | sed \'N;s/\\n/\\t/\' | '
-    cmd1 += 'shuf --random-source=<(openssl enc -aes-256-ctr '
-    cmd1 += '-pass pass:$(zcat -f {} | wc -c) '
-    cmd1 += '-nosalt </dev/zero 2>/dev/null) | '
-    cmd1 += 'split -d -l {} - {}.'
-    cmd1 = cmd1.format(
-        ta,
-        ta,
-        nlines,
-        prefix)
-    run_shell_cmd(cmd1)
+    run_shell_cmd(
+        'zcat -f {ta} | sed \'N;s/\\n/\\t/\' | '
+        'shuf --random-source=<(openssl enc -aes-256-ctr '
+        '-pass pass:${random_seed} -nosalt </dev/zero 2>/dev/null) | '
+        'split -d -l {nlines} - {prefix}.'.format(
+            ta=ta,
+            random_seed=random_seed,
+            nlines=nlines,
+            prefix=prefix,
+        )
+    )
 
-    cmd2 = 'zcat -f {} | '
-    cmd2 += 'awk \'BEGIN{{OFS="\\t"}} '
-    cmd2 += '{{printf "%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n'
-    cmd2 += '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n",'
-    cmd2 += '$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12}}\' | '
-    cmd2 += 'gzip -nc > {}'
-    cmd2 = cmd2.format(
-        tmp_pr1,
-        ta_pr1)
-    run_shell_cmd(cmd2)
+    run_shell_cmd(
+        'zcat -f {tmp_pr1} | '
+        'awk \'BEGIN{{OFS="\\t"}} '
+        '{{printf "%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n'
+        '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n",'
+        '$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12}}\' | '
+        'gzip -nc > {ta_pr1}'.format(
+            tmp_pr1=tmp_pr1,
+            ta_pr1=ta_pr1,
+        )
+    )
 
-    cmd3 = 'zcat -f {} | '
-    cmd3 += 'awk \'BEGIN{{OFS="\\t"}} '
-    cmd3 += '{{printf "%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n'
-    cmd3 += '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n",'
-    cmd3 += '$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12}}\' | '
-    cmd3 += 'gzip -nc > {}'
-    cmd3 = cmd3.format(
-        tmp_pr2,
-        ta_pr2)
-    run_shell_cmd(cmd3)
+    run_shell_cmd(
+        'zcat -f {tmp_pr2} | '
+        'awk \'BEGIN{{OFS="\\t"}} '
+        '{{printf "%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n'
+        '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n",'
+        '$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12}}\' | '
+        'gzip -nc > {ta_pr2}'.format(
+            tmp_pr2=tmp_pr2,
+            ta_pr2=ta_pr2,
+        )
+    )
 
     rm_f([tmp_pr1, tmp_pr2])
     return ta_pr1, ta_pr2
@@ -125,9 +146,13 @@ def main():
 
     log.info('Making self-pseudo replicates...')
     if args.paired_end:
-        ta_pr1, ta_pr2 = spr_pe(args.ta, args.out_dir)
+        ta_pr1, ta_pr2 = spr_pe(
+            args.ta, args.pseudoreplication_random_seed, args.out_dir,
+        )
     else:
-        ta_pr1, ta_pr2 = spr_se(args.ta, args.out_dir)
+        ta_pr1, ta_pr2 = spr_se(
+            args.ta, args.pseudoreplication_random_seed, args.out_dir,
+        )
 
     log.info('List all files in output directory...')
     ls_l(args.out_dir)


### PR DESCRIPTION
Added a new parameter to fix random seed for pseudoreplication.
- `atac.pseudoreplication_random_seed`.
- If `0` then input TAG-ALIGN's file size (in bytes) is used for random seed.

